### PR TITLE
child account creation,  fixes #64

### DIFF
--- a/__tests__/services/DerivationService.spec.ts
+++ b/__tests__/services/DerivationService.spec.ts
@@ -15,10 +15,11 @@
  */
 import {DerivationService, DerivationPathLevels} from '@/services/DerivationService'
 import {WalletService} from '@/services/WalletService'
-
+const {DEFAULT_WALLET_PATH} = WalletService
 
 // Standard account paths
 const standardPaths = {
+  // the path number one is the DEFAULT_WALLET_PATH
   2: 'm/44\'/4343\'/1\'/0\'/0\'',
   3: 'm/44\'/4343\'/2\'/0\'/0\'',
   4: 'm/44\'/4343\'/3\'/0\'/0\'',
@@ -35,7 +36,7 @@ describe('services/DerivationService ==>', () => {
     test('increase standard paths as expected', () => {
       expect(
         [...Array(9).keys()].map(index => new DerivationService().incrementPathLevel(
-          WalletService.DEFAULT_WALLET_PATH, DerivationPathLevels.Account, index + 1,
+          DEFAULT_WALLET_PATH, DerivationPathLevels.Account, index + 1,
         ))).toEqual(Object.values(standardPaths))
     })
   })
@@ -45,7 +46,33 @@ describe('services/DerivationService ==>', () => {
       expect(
         [...Array(9).keys()].map(index => new DerivationService().decrementPathLevel(
           standardPaths[10], DerivationPathLevels.Account, index + 1,
-        ))).toEqual([ WalletService.DEFAULT_WALLET_PATH, ...Object.values(standardPaths).slice(0,8) ].reverse())
+        ))).toEqual([ DEFAULT_WALLET_PATH, ...Object.values(standardPaths).slice(0,8) ].reverse())
+    })
+  })
+
+  describe('getNextAccountPath() should', () => {
+    test('return default path when provided an empty array', () => {
+      expect(new DerivationService().getNextAccountPath([])).toBe(DEFAULT_WALLET_PATH)
+    })
+
+    test('return the first missing consecutive path when it is the default one', () => {
+      const paths = [standardPaths[2], standardPaths[3]]
+      expect(new DerivationService().getNextAccountPath(paths)).toBe(DEFAULT_WALLET_PATH)
+    })
+
+    test('return the first missing consecutive path when it is the second one', () => {
+      const paths = [standardPaths[3], standardPaths[5], DEFAULT_WALLET_PATH]
+      expect(new DerivationService().getNextAccountPath(paths)).toBe(standardPaths[2])
+    })
+
+    test('return the first missing consecutive path when it is in the middle', () => {
+      const paths = [standardPaths[2], DEFAULT_WALLET_PATH, standardPaths[4],]
+      expect(new DerivationService().getNextAccountPath(paths)).toBe(standardPaths[3])
+    })
+
+    test('return the next path when all paths are consecutive', () => {
+      const paths = [standardPaths[2], standardPaths[3], DEFAULT_WALLET_PATH]
+      expect(new DerivationService().getNextAccountPath(paths)).toBe(standardPaths[4])
     })
   })
 })

--- a/src/core/utils/NotificationType.ts
+++ b/src/core/utils/NotificationType.ts
@@ -50,6 +50,7 @@ export enum NotificationType {
   LOADING = 'Loading',
   MAX_APPROVAL_MORE_THAN_10_ERROR = 'max_approval_amount_more_than_10',
   MAX_REMOVAL_MORE_THAN_10_ERROR = 'max_removal_amount_more_than_10',
+  TOO_MANY_SEED_WALLETS_ERROR = 'error_too_many_seed_wallets',
   MIN_APPROVAL_LESS_THAN_0_ERROR = 'min_approval_amount_less_than_0',
   MIN_REMOVAL_LESS_THAN_0_ERROR = 'min_removal_amount_less_than_0',
   MNEMONIC_GENERATION_ERROR = 'mnemonic_generation_error',

--- a/src/language/en-US.json
+++ b/src/language/en-US.json
@@ -958,6 +958,7 @@
   "error_peer_connection_went_wrong": "Something went wrong when connecting to the node {peerUrl} timed out",
   "error_incorrect_url": "This is not a valid URL",
   "error_delete_all_peers": "You can not delete all the nodes",
+  "error_too_many_seed_wallets": "You cannot create more than {maxSeedWalletsNumber} child wallets",
   "success_account_unlocked": "Account unlocked successfully",
   "success_password_changed": "Your password was updated successfully. You will now be logged out.",
   "success_settings_updated": "Your settings have been updated successfully.",


### PR DESCRIPTION
- Fix  max number of child accounts
- implement getNextAccountPath method to handle the case when existing wallet paths are not consecutive