### PR TITLE
add button to clear staged transactions when they are more than 1, fixes #88

### DIFF
--- a/src/language/en-US.json
+++ b/src/language/en-US.json
@@ -1185,5 +1185,6 @@
   "info_connecting_peer": "Connecting to the node {peerUrl} ...",
   "no_data_transactions": "No transactions were found for this account",
   "no_data_namespaces": "No namespaces were found for this account",
-  "no_data_mosaics": "No mosaics were found for this account"
+  "no_data_mosaics": "No mosaics were found for this account",
+  "clear_staged_transactions": "Discard all transactions"
 }

--- a/src/store/Wallet.ts
+++ b/src/store/Wallet.ts
@@ -356,6 +356,7 @@ export default {
       // - update state
       return Vue.set(state, 'stagedTransactions', staged)
     },
+    clearStagedTransaction: (state) => Vue.set(state, 'stagedTransactions', []),
     addSignedTransaction: (state, transaction: SignedTransaction) => {
       // - get previously signed transactions
       const signed = state.signedTransactions
@@ -628,6 +629,9 @@ export default {
     },
     ADD_STAGED_TRANSACTION({commit}, stagedTransaction: Transaction) {
       commit('addStagedTransaction', stagedTransaction)
+    },
+    CLEAR_STAGED_TRANSACTIONS({commit}, stagedTransaction: Transaction) {
+      commit('clearStagedTransaction')
     },
     RESET_TRANSACTION_STAGE({commit}) {
       commit('setStagedTransactions', [])

--- a/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmation.vue
+++ b/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmation.vue
@@ -27,7 +27,16 @@
         </div>
       </div>
 
-      <div slot="footer" class="modal-footer"></div>
+      <div slot="footer" class="modal-footer">
+        <div v-if="stagedTransactions && stagedTransactions.length > 1">
+          <span
+            class="clear-staged-transactions"
+            @click="$store.dispatch('wallet/CLEAR_STAGED_TRANSACTIONS'); show = false"
+          >
+            {{ $t('clear_staged_transactions') }}
+          </span>
+        </div>
+      </div>
     </Modal>
   </div>
 </template>
@@ -38,6 +47,8 @@ export default class ModalTransactionConfirmation extends ModalTransactionConfir
 </script>
 
 <style lang="less">
+@import '../../resources/css/variables.less';
+
 .modal-transaction-confirmation {
   min-width: 8.5rem;
   max-width: 12rem;
@@ -61,5 +72,10 @@ export default class ModalTransactionConfirmation extends ModalTransactionConfir
 
 .float-right {
   float: right;
+}
+
+.clear-staged-transactions {
+  font-size: @smallFont;
+  cursor: pointer;
 }
 </style>


### PR DESCRIPTION
for some reason I can't reproduce the behaviour described #88, although it happened to me this morning

I suspect this bad state comes from bad network connexion

I added an option to clear all staged transactions from the confirmation modal whem there are more than 1 staged transactions in the store