### PR TITLE
react to newly added transactions, fixes #69

### DIFF
--- a/src/services/RESTService.ts
+++ b/src/services/RESTService.ts
@@ -175,6 +175,7 @@ export class RESTService extends AbstractService {
     const confirmed = listener.confirmed(address).subscribe(
       transaction => {
         context.dispatch('wallet/ADD_TRANSACTION', {group: 'confirmed', transaction}, {root: true})
+        context.dispatch('wallet/ON_NEW_TRANSACTION', transaction, {root: true})
         context.dispatch('notification/ADD_SUCCESS', NotificationType.NEW_CONFIRMED_TRANSACTION, {root: true})
       },
       err => context.dispatch('diagnostic/ADD_ERROR', err, {root: true}))

--- a/src/store/Wallet.ts
+++ b/src/store/Wallet.ts
@@ -324,17 +324,17 @@ export default {
     unconfirmedTransactions: (state, transactions) => Vue.set(state, 'unconfirmedTransactions', transactions),
     partialTransactions: (state, transactions) => Vue.set(state, 'partialTransactions', transactions),
     setSubscriptions: (state, data) => Vue.set(state, 'subscriptions', data),
-    addSubscriptions: (state, payload) => {
+    addSubscriptions: (state, payload: {address: string, subscriptions: SubscriptionType}) => {
       const {address, subscriptions} = payload
       // skip when subscriptions is an empty array
-      if (!subscriptions.length) return
+      if (!subscriptions.subscriptions.length) return
       // get current subscriptions from state
       const oldSubscriptions = state.subscriptions[address] || []
       // update subscriptions
-      const newSubscriptions = oldSubscriptions.push(subscriptions)
+      const newSubscriptions = [...oldSubscriptions, subscriptions]
       // update state
       Vue.set(state.subscriptions, address, newSubscriptions)
-    },
+     },
     addTransactionToCache: (state, payload): Record<string, Transaction[]> => {
       if (payload === undefined) return
       const {transaction, hash, cacheKey} = payload


### PR DESCRIPTION
based on #101 

Came up with this after many thoughts
Making a plugin or an event subscription seemed overkilled and complicated:

- We only want to react to transactions added by the transaction confirmed listener
=> Plugin option: Plugins react to mutations, and new transactions mutations that come from the listener are tricky to segregate
=> Event listener option: Seemed overkill compared to this proposition