### PR TITLE
Removes the address binding namespace from the Mosaic list (fix #185)

### DIFF
--- a/src/components/TableDisplay/TableDisplay.vue
+++ b/src/components/TableDisplay/TableDisplay.vue
@@ -88,6 +88,7 @@
           :namespace-id="modalFormsProps.namespaceId"
           :alias-target="modalFormsProps.aliasTarget"
           :alias-action="modalFormsProps.aliasAction"
+          :asset-type="assetType"
           @on-confirmation-success="closeModal('aliasTransaction')"
         />
       </template>

--- a/src/views/forms/FormAliasTransaction/FormAliasTransaction.vue
+++ b/src/views/forms/FormAliasTransaction/FormAliasTransaction.vue
@@ -41,7 +41,7 @@
                   <option value="mosaic">
                     {{ $t('option_link_mosaic') }}
                   </option>
-                  <option value="address">
+                  <option v-show="assetType === 'namespace'" value="address">
                     {{ $t('option_link_address') }}
                   </option>
                 </select>

--- a/src/views/forms/FormAliasTransaction/FormAliasTransactionTs.ts
+++ b/src/views/forms/FormAliasTransaction/FormAliasTransactionTs.ts
@@ -74,6 +74,11 @@ export class FormAliasTransactionTs extends FormTransactionBase {
   @Prop({ default: null }) aliasTarget: MosaicId | Address
   @Prop({ default: null, required: true }) aliasAction: AliasAction
   @Prop({ default: false }) disableSubmit: boolean
+  /**
+   * Type of assets shown in the form alias
+   * @type {string}
+   */
+  @Prop({default: 'namespace'}) assetType: string
 
   /**
    * Alias action


### PR DESCRIPTION
fix #185 