### PR TITLE
WIP: Refactor account selector to profile manager

### DIFF
--- a/src/components/ProfileInfo/ProfileInfo.less
+++ b/src/components/ProfileInfo/ProfileInfo.less
@@ -1,0 +1,53 @@
+@import "../../views/resources/css/variables.less";
+
+.profile-info-container {
+  position: relative;
+  color: @white;
+  font-size: @biggerFont;
+  /deep/.back-button{
+    line-height: 1.5;
+  }
+  .profile-info-content {
+    padding  : .16rem;
+    color    :@purpleDark;
+    font-size: @smallerFont;
+  }
+
+  /deep/.ivu-poptip-popper {
+    width: 3.68rem;
+  }
+
+  .ivu-row {
+    margin-top: .1rem;
+  }
+
+  .row-label {
+    color      : @black;
+    font-weight: 400;
+    line-height: .22rem;
+  }
+
+  .row-value {
+    color      : @purpleDark;
+    font-weight: bold;
+    line-height: .22rem;
+  }
+
+  .profile-info-controls {
+    .ivu-row {
+      cursor: pointer;
+      &:hover{
+        color:lighten(@purpleDark,15%)
+      }
+    }
+
+    .profile-manage {
+      margin-bottom: .25rem;
+    }
+
+
+    .profile-logout {
+      text-align: right;
+    }
+  }
+}

--- a/src/components/ProfileInfo/ProfileInfo.vue
+++ b/src/components/ProfileInfo/ProfileInfo.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="profile-info-container">
+    <Poptip placement="bottom-end" offset="10" :capture="true">
+      <Icon type="ios-contact-outline" />
+      <div slot="content" class="profile-info-content">
+        <div>
+          <Row>
+            <i-col span="12" class="row-label">
+              {{ $t('profile_name') }}&nbsp;:
+            </i-col>
+            <i-col span="12" class="row-value">
+              {{ currentAccount.accountName }}
+            </i-col>
+          </Row>
+          <Row>
+            <i-col span="12" class="row-label">
+              {{ $t('current_network') }}&nbsp;:
+            </i-col>
+            <i-col span="12" class="row-value">
+              {{ currentAccount.networkType }}
+            </i-col>
+          </Row>
+          <Row>
+            <i-col span="12" class="row-label">
+              {{ $t('current_account') }}&nbsp;:
+            </i-col>
+            <i-col span="12" class="row-value">
+              {{ currentWallet.name }}
+            </i-col>
+          </Row>
+        </div>
+        <Divider />
+        <div class="profile-info-controls">
+          <div class="profile-manage">
+            <Row>
+              <i-col>
+                <div @click="isShowingAccountCreationModal = true">
+                  {{ $t('add_an_account') }}
+                </div>
+              </i-col>
+            </Row>
+            <Row>
+              <i-col>
+                <div @click="isShowingChangePasswordModal = true">
+                  {{ $t('change_password') }}
+                </div>
+              </i-col>
+            </Row>
+          </div>
+          <div class="profile-safety">
+            <Row>
+              <i-col>
+                <span @click="isShowingExportMnemonicModal = true">{{ $t('backup_current_mnemonic') }}</span>
+              </i-col>
+            </Row>
+            <Row>
+              <i-col>{{ $t('delete_current_account') }}</i-col>
+            </Row>
+            <Row>
+              <i-col>{{ $t('delete_current_profile') }}</i-col>
+            </Row>
+          </div>
+          <Divider />
+          <div class="profile-logout">
+            <Row>
+              <i-col><span @click="logout">{{ $t("logout") }}</span></i-col>
+            </Row>
+          </div>
+        </div>
+      </div>
+    </Poptip>
+    <ModalFormSubWalletCreation
+      :visible="isShowingAccountCreationModal"
+      @close="isShowingAccountCreationModal = false"
+    />
+    <ModalMnemonicExport :visible="isShowingExportMnemonicModal" @close="isShowingExportMnemonicModal = false" />
+    <ModalChangePassword :visible="isShowingChangePasswordModal" @close="isShowingChangePasswordModal = false" />
+  </div>
+</template>
+<script lang="ts">
+import { ProfileInfoTs } from './ProfileInfoTs'
+export default class ProfileInfo extends ProfileInfoTs { }
+</script>
+<style lang="less" scoped>
+  @import "./ProfileInfo.less";
+</style>

--- a/src/components/ProfileInfo/ProfileInfoTs.ts
+++ b/src/components/ProfileInfo/ProfileInfoTs.ts
@@ -1,0 +1,53 @@
+import { Vue, Component } from 'vue-property-decorator'
+import { mapGetters } from 'vuex'
+import { AccountModel } from '@/core/database/entities/AccountModel'
+import { WalletModel } from '@/core/database/entities/WalletModel'
+// @ts-ignore
+import ModalFormSubWalletCreation from '@/views/modals/ModalFormSubWalletCreation/ModalFormSubWalletCreation.vue'
+// @ts-ignore
+import ModalMnemonicExport from '@/views/modals/ModalMnemonicExport/ModalMnemonicExport.vue'
+// @ts-ignore
+import ModalChangePassword from '@/views/modals/ModalChangePassword/ModalChangePassword.vue'
+@Component({
+  computed: {
+    ...mapGetters({
+      currentAccount: 'account/currentAccount',
+      currentWallet: 'wallet/currentWallet',
+    }),
+  },
+  components:{
+    ModalFormSubWalletCreation,
+    ModalMnemonicExport,
+    ModalChangePassword,
+  },
+})
+export class ProfileInfoTs extends Vue {
+  public currentAccount: AccountModel
+  public currentWallet: WalletModel
+  public isAddingAccount: boolean=false
+  public isExportingMnemonic: boolean=false
+  public isChangingPassword: boolean=false
+  
+  public get isShowingAccountCreationModal(): boolean{
+    return this.isAddingAccount
+  }
+  public set isShowingAccountCreationModal(val: boolean){
+    this.isAddingAccount = val
+  }
+  public get isShowingExportMnemonicModal(): boolean{
+    return this.isExportingMnemonic
+  }
+  public set isShowingExportMnemonicModal(val: boolean){
+    this.isExportingMnemonic = val
+  }
+  public get isShowingChangePasswordModal(): boolean{
+    return this.isChangingPassword
+  }
+  public set isShowingChangePasswordModal(val: boolean){
+    this.isChangingPassword = val
+  }
+  public async logout() {
+    await this.$store.dispatch('account/LOG_OUT')
+    this.$router.push({name: 'accounts.login'})
+  }
+}

--- a/src/components/Setting/Setting.less
+++ b/src/components/Setting/Setting.less
@@ -1,0 +1,5 @@
+@import "../../views/resources/css/variables.less";
+.setting-container{
+  color: @white;
+  font-size: @biggerFont;
+}

--- a/src/components/Setting/Setting.vue
+++ b/src/components/Setting/Setting.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="setting-container">
+    <Icon type="ios-settings" @click="toggleSetting" />
+    <ModalSetting :visible="isShowModal" @close="onClose" />
+  </div>
+</template>
+<script lang="ts">
+import { SettingTs } from './SettingTs'
+export default class Setting extends SettingTs { }
+</script>
+<style lang="less" scoped>
+  @import './Setting.less';
+</style>

--- a/src/components/Setting/SettingTs.ts
+++ b/src/components/Setting/SettingTs.ts
@@ -1,0 +1,16 @@
+import { Vue, Component } from 'vue-property-decorator'
+// @ts-ignore
+import ModalSetting from '@/views/modals/ModalSetting/ModalSetting.vue'
+
+@Component({
+  components: { ModalSetting },
+})
+export class SettingTs extends Vue {
+  public isShowModal: boolean = false
+  public toggleSetting(){
+    this.isShowModal = !this.isShowModal
+  }
+  onClose(){
+    this.isShowModal = false
+  }
+}

--- a/src/components/SymbolTabs/SymbolTabPane/SymbolTabPane.less
+++ b/src/components/SymbolTabs/SymbolTabPane/SymbolTabPane.less
@@ -1,0 +1,11 @@
+@import "../../../views/resources/css/variables.less";
+
+.tab-content-container {
+  flex-shrink: 0;
+  width      : 100%;
+  visibility : hidden;
+
+  &.active-content {
+    visibility: visible;
+  }
+}

--- a/src/components/SymbolTabs/SymbolTabPane/SymbolTabPane.vue
+++ b/src/components/SymbolTabs/SymbolTabPane/SymbolTabPane.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="tab-content-container" :class="[currentActiveIndex === currentIndex ? 'active-content' : '']">
+    <div v-if="currentActiveIndex === currentIndex">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { SymbolTabPaneTs } from './SymbolTabPaneTs'
+export default class SymbolTabPane extends SymbolTabPaneTs { }
+</script>
+
+<style lang="less" scoped>
+  @import "./SymbolTabPane.less";
+</style>

--- a/src/components/SymbolTabs/SymbolTabPane/SymbolTabPaneTs.ts
+++ b/src/components/SymbolTabs/SymbolTabPane/SymbolTabPaneTs.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2020 NEM Foundation (https://nem.io)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Vue, Component, Prop } from 'vue-property-decorator'
+@Component
+export class SymbolTabPaneTs extends Vue {
+  @Prop({ default: '' }) label: string
+  public currentIndex = null
+  public get currentActiveIndex() {
+    return this.$parent['activeNavIndex']
+  }
+}

--- a/src/components/SymbolTabs/SymbolTabs.less
+++ b/src/components/SymbolTabs/SymbolTabs.less
@@ -1,0 +1,38 @@
+@import "../../views/resources/css/variables.less";
+
+.symbol-tabs-content {
+  width   : 100%;
+  overflow: hidden;
+
+  .tabs-content {
+    display       : flex;
+    flex-direction: row;
+    will-change   : transform;
+    transition    : transform .3s ease-in-out;
+  }
+}
+
+.vertical {
+  display              : grid;
+  grid-template-columns: 20% 80%;
+
+  .symbol-tab-nav {
+    padding-top: .2rem;
+
+    .nav-item {
+      padding-bottom: 0.35rem;
+      font-size     : @normalFont;
+      font-weight   : 400;
+      color         : #666;
+      cursor        : pointer;
+
+      &.active-item {
+        color: @purple
+      }
+    }
+  }
+
+  .symbol-tabs-content {
+    padding: .05rem;
+  }
+}

--- a/src/components/SymbolTabs/SymbolTabs.vue
+++ b/src/components/SymbolTabs/SymbolTabs.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="symbol-tab-container" :class="[direction === 'horizontal' ? 'horizontal' : 'vertical']">
+    <div class="symbol-tab-nav">
+      <div
+        v-for="({label},index) in tabPaneNavigators" :key="index" class="nav-item"
+        :class="[index === activeNavIndex ? 'active-item' : 'inactive-item']" @click="onTabChange(index)"
+      >
+        <span>{{ label }}</span>
+      </div>
+    </div>
+    <div class="symbol-tabs-content">
+      <div class="tabs-content" :style="contentStyle">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+import { SymbolTabsTs } from './SymbolTabsTs'
+export default class SymbolTabs extends SymbolTabsTs { }
+</script>
+<style lang="less" scoped>
+  @import "./SymbolTabs.less";
+</style>

--- a/src/components/SymbolTabs/SymbolTabsTs.ts
+++ b/src/components/SymbolTabs/SymbolTabsTs.ts
@@ -1,0 +1,33 @@
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+
+@Component
+export class SymbolTabsTs extends Vue {
+  @Prop({ default: 'direction' }) direction: string
+  public tabPaneNavigators: Array<any> = []
+  public activeNavIndex: number = 0
+  public contentStyle = {
+    transform: 'translateX(0)',
+  }
+
+  /**
+   *  Get the tabPane list
+   * */
+  public getTabPaneComponents() {
+    const tabPanes = []
+    this.$children.forEach((pane,index) => {
+      if (pane.$options.name === 'SymbolTabPaneTs') {
+        tabPanes.push(pane)
+        pane['currentIndex'] = index
+      }
+    })
+    return tabPanes
+  }
+  public onTabChange(index) {
+    this.activeNavIndex = index = parseInt(index)
+    this.contentStyle.transform = index === 0 ? `translateX(${index})` : `translateX(-${index}00%)`
+  }
+  mounted() {
+    this.tabPaneNavigators = this.getTabPaneComponents()
+  }
+}

--- a/src/components/WalletSelectorPanel/WalletSelectorPanel.vue
+++ b/src/components/WalletSelectorPanel/WalletSelectorPanel.vue
@@ -39,7 +39,7 @@
 
     <div class="wallet-switch-footer-container">
       <span class="add-wallet pointer" @click="hasAddWalletModal = true">
-        <Icon type="md-add-circle" />{{ $t('button_add_wallet') }}
+        <Icon type="md-add-circle" />{{ $t('add_an_account') }}
       </span>
       <div class="wallet-switch-header-right-container" @click="hasMnemonicExportModal = true">
         <span>

--- a/src/language/en-US.json
+++ b/src/language/en-US.json
@@ -1056,7 +1056,7 @@
   "approval_greater_than_cosignatories": "There are {delta} more required cosignatories for min. approval than available cosignatories. Please add cosignatories or reduce the min. approval number.",
   "removal_greater_than_cosignatories": "There are {delta} more required cosignatories for min removal than available cosignatories. Please add cosignatories or reduce the min. removal number.",
   "too_many_cosignatories": "The maximum number of cosignatories is {maxCosignatoriesPerAccount}, please remove {delta} cosignatories",
-  "button_add_wallet": "Add an account",
+  "add_an_account": "Add an account",
   "option_root_namespace": "Root Namespace",
   "option_sub_namespace": "Sub namespace",
   "option_child_wallet": "I want to create a child account for my profile",
@@ -1209,5 +1209,14 @@
   "rules_describe":"Rules description",
   "Estimated_period_of_validity":"Estimated Period Of Validity",
   "no_data_namespace_tips":"You do not have a namespace, please create one first",
-  "current_validity":"Expires in"
+  "current_validity":"Expires in",
+  "profile_name":"Profile name",
+  "current_network":"Current network",
+  "current_account":"Current account",
+  "logout":"Logout",
+  "import_seed_account":"Import seed account",
+  "import_private_key":"Import private key",
+  "backup_current_mnemonic":"Backup current mnemonic",
+  "delete_current_account":"Delete current account",
+  "delete_current_profile":"Delete current profile"
 }

--- a/src/language/zh-CN.json
+++ b/src/language/zh-CN.json
@@ -332,7 +332,7 @@
   "address_alias_not_exist": "地址别名不存在",
   "export_mnemonic": "导出助记词",
   "backup_mnemonic": "备份助记词",
-  "button_add_wallet": "增加或导入钱包",
+  "add_an_account": "增加或导入钱包",
   "confirm_backup": "确认备份",
   "getting_a_mnemonic_equals_ownership_of_a_wallet_asset": "获得助记词等于拥有钱包资产所有权",
   "use_paper_and_pen_to_correctly_copy_mnemonics": "使用纸和笔正确抄写助记词,如果你的手机丢失、被盗、损坏,助记词将可以恢复你的资产",
@@ -1161,5 +1161,14 @@
   "rules_describe":"规则描述",
   "Estimated_period_of_validity":"预估有效期",
   "no_data_namespace_tips":"您还没有父命名空间，请先创建一个父命名空间",
-  "current_validity":"当前有效期"
+  "current_validity":"当前有效期",
+  "profile_name":"账户名称",
+  "current_network":"当前网络",
+  "current_wallet":"钱包",
+  "logout":"注销",
+  "import_seed_account":"导入助记词",
+  "import_private_key":"导入私钥",
+  "backup_current_mnemonic":"备份当前账户助记词",
+  "delete_current_account":"删除钱包",
+  "delete_current_profile":"删除账户"
 }

--- a/src/views/layout/PageLayout/PageLayout.vue
+++ b/src/views/layout/PageLayout/PageLayout.vue
@@ -26,10 +26,12 @@
             <Icon :type="'ios-code-working'" size="22" class="debug-console-trigger-icon" />
             <span>&nbsp;{{ $t('top_window_console') }}</span>
           </div>
-
+         
           <PeerSelector />
           <LanguageSelector />
-          <WalletSelectorField @input="onChangeWallet" />
+          <!-- <WalletSelectorField @input="onChangeWallet" /> -->
+          <Setting />
+          <ProfileInfo />
         </div>
       </div>
     </div>

--- a/src/views/layout/PageLayout/PageLayoutTs.ts
+++ b/src/views/layout/PageLayout/PageLayoutTs.ts
@@ -35,6 +35,10 @@ import LanguageSelector from '@/components/LanguageSelector/LanguageSelector.vue
 // @ts-ignore
 import WalletSelectorField from '@/components/WalletSelectorField/WalletSelectorField.vue'
 // @ts-ignore
+import ProfileInfo from '@/components/ProfileInfo/ProfileInfo.vue'
+// @ts-ignore
+import Setting from '@/components/Setting/Setting.vue'
+// @ts-ignore
 import ModalDebugConsole from '@/views/modals/ModalDebugConsole/ModalDebugConsole.vue'
 import {URLInfo} from '@/core/utils/URLInfo'
 
@@ -48,6 +52,8 @@ import {URLInfo} from '@/core/utils/URLInfo'
     LanguageSelector,
     WalletSelectorField,
     ModalDebugConsole,
+    ProfileInfo,
+    Setting,
   },
   computed: {
     ...mapGetters({

--- a/src/views/modals/ModalChangePassword/ModalChangePassword.less
+++ b/src/views/modals/ModalChangePassword/ModalChangePassword.less
@@ -1,0 +1,1 @@
+@import "../../resources/css/variables.less";

--- a/src/views/modals/ModalChangePassword/ModalChangePassword.vue
+++ b/src/views/modals/ModalChangePassword/ModalChangePassword.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <Modal
+      v-model="isShowModal" class="change-password-modal-container modal-container" 
+      :title="$t('change_password')"
+      :footer-hide="true" 
+      :transfer="false"
+    >
+      <FormAccountPasswordUpdate />
+    </Modal>
+  </div>
+</template>
+<script lang="ts">
+import { ModalChangePasswordTs } from './ModalChangePasswordTs'
+export default class ModalChangePassword extends ModalChangePasswordTs { }
+</script>
+<style lang="less" scoped>
+  @import "./ModalChangePassword.less";
+</style>

--- a/src/views/modals/ModalChangePassword/ModalChangePasswordTs.ts
+++ b/src/views/modals/ModalChangePassword/ModalChangePasswordTs.ts
@@ -1,0 +1,16 @@
+import { Vue, Component, Prop } from 'vue-property-decorator'
+// @ts-ignore
+import FormAccountPasswordUpdate from '@/views/forms/FormAccountPasswordUpdate/FormAccountPasswordUpdate.vue'
+@Component({
+  components: { FormAccountPasswordUpdate },
+})
+export class ModalChangePasswordTs extends Vue {
+  @Prop({default:false}) visible: boolean
+
+  public get isShowModal(): boolean {
+    return this.visible
+  }
+  public set isShowModal(newVal: boolean) {
+    this.$emit('close')
+  }
+}

--- a/src/views/modals/ModalFormAccountUnlock/ModalFormAccountUnlock.vue
+++ b/src/views/modals/ModalFormAccountUnlock/ModalFormAccountUnlock.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="container">
+    <!-- hack the fixed will be invalid -->
     <Modal
       v-model="show"
       :title="$t('modal_account_unlock_title')"
-      :transfer="false"
+      :transfer="true"
       class-name="modal-container"
     >
       <FormAccountUnlock @success="onAccountUnlocked" @error="onError" />

--- a/src/views/modals/ModalSetting/ModalSetting.less
+++ b/src/views/modals/ModalSetting/ModalSetting.less
@@ -1,0 +1,12 @@
+.setting-modal-container {
+  /deep/.ivu-modal {
+    width     : 12rem !important;
+    .auto-complete-size{
+      width: 100%;
+    }
+  }
+  .about-container{
+    max-height: 6.5rem;
+    overflow-y: auto;
+  }
+}

--- a/src/views/modals/ModalSetting/ModalSetting.vue
+++ b/src/views/modals/ModalSetting/ModalSetting.vue
@@ -1,0 +1,27 @@
+<template>
+  <div>
+    <Modal
+      v-model="isShowModal" class="setting-modal-container" :footer-hide="true"
+      :title="$t('setting')"
+    >
+      <SymbolTabs class="setting-tabs-container">
+        <SymbolTabPane label="General">
+          <FormGeneralSettings />
+        </SymbolTabPane>
+        <!-- <SymbolTabPane label="Profile password">
+          <FormAccountPasswordUpdate />
+        </SymbolTabPane> -->
+        <SymbolTabPane label="About">
+          <AboutPage />
+        </SymbolTabPane>
+      </SymbolTabs>
+    </Modal>
+  </div>
+</template>
+<script lang="ts">
+import { ModalSettingTs } from './ModalSettingTs'
+export default class ModalSetting extends ModalSettingTs { }
+</script>
+<style lang="less" scoped>
+  @import "./ModalSetting.less";
+</style>

--- a/src/views/modals/ModalSetting/ModalSettingTs.ts
+++ b/src/views/modals/ModalSetting/ModalSettingTs.ts
@@ -1,0 +1,30 @@
+import { Vue, Component, Prop } from 'vue-property-decorator'
+// @ts-ignore
+import FormGeneralSettings from '@/views/forms/FormGeneralSettings/FormGeneralSettings.vue'
+// @ts-ignore
+import FormAccountPasswordUpdate from '@/views/forms/FormAccountPasswordUpdate/FormAccountPasswordUpdate.vue'
+// @ts-ignore
+import AboutPage from '@/views/pages/settings/AboutPage/AboutPage.vue'
+// @ts-ignore
+import SymbolTabs from '@/components/SymbolTabs/SymbolTabs.vue'
+// @ts-ignore
+import SymbolTabPane from '@/components/SymbolTabs/SymbolTabPane/SymbolTabPane.vue'
+@Component({
+  components:{
+    FormGeneralSettings,
+    FormAccountPasswordUpdate,
+    AboutPage,
+    SymbolTabs,
+    SymbolTabPane,
+  },
+})
+export class ModalSettingTs extends Vue {
+  @Prop({default:false}) visible: boolean
+
+  public get isShowModal(): boolean {
+    return this.visible
+  }
+  public set isShowModal(newVal: boolean) {
+    this.$emit('close')
+  }
+}

--- a/src/views/pages/settings/AboutPage/AboutPage.less
+++ b/src/views/pages/settings/AboutPage/AboutPage.less
@@ -1,0 +1,27 @@
+@import "../../../resources/css/variables.less";
+
+.about-container {
+  display   : block;
+  width     : 100%;
+  clear     : both;
+  min-height: 1rem;
+
+  .form-row {
+    width                : 100%;
+    margin-top           : @normalFont;
+    margin-bottom        : @normalFont;
+    display              : grid;
+    grid-template-columns: 2.5rem auto;
+    font-size            : @normalFont;
+
+    .value {
+      font-weight: bolder;
+      word-break : break-all;
+    }
+  }
+
+  .subtitle {
+    font-size : @biggerFont;
+    margin-top: .5rem;
+  }
+}

--- a/src/views/pages/settings/AboutPage/AboutPage.vue
+++ b/src/views/pages/settings/AboutPage/AboutPage.vue
@@ -150,35 +150,6 @@ export default class AboutPage extends Vue {
 </script>
 
 <style lang="less" scoped>
-.about-container {
-  display: block;
-  width: 100%;
-  clear: both;
-  min-height: 1rem;
-
-  .form-row {
-    width: 100%;
-    margin-top: 20px;
-    margin-bottom: 20px;
-
-    .label {
-      float: left;
-      font-size: 20px;
-      width: 250px;
-    }
-
-    .value {
-      float: left;
-      margin-left: 50px;
-      font-size: 20px;
-      font-weight: bolder;
-    }
-  }
-
-  .subtitle {
-    font-size: 25px;
-    margin-top: 50px;
-  }
-}
+  @import "./AboutPage.less";
 </style>
 

--- a/src/views/resources/css/common.less
+++ b/src/views/resources/css/common.less
@@ -314,29 +314,25 @@ textarea {
   -webkit-animation: fadeIn .5s;
 }
 
-.wrap {
-  .ivu-input {
-    border: none;
-    border-radius: 0;
-    border-bottom: 1px solid @border;
-  }
+.ivu-input {
+  border       : none;
+  border-radius: 0;
+  border-bottom: 1px solid @border;
+}
 
-  .ivu-input:focus {
-    box-shadow: none;
-    border-bottom: 1px solid @border;
-  }
+.ivu-input:focus {
+  box-shadow   : none;
+  border-bottom: 1px solid @border;
+}
 
-  .input_point {
-    input {
-      border: none;
-      border-bottom: 1px solid @border;
-    }
+.input_point {
+  input {
+    border       : none;
+    border-bottom: 1px solid @border;
   }
 }
 
-.ivu-modal-wrap {
-  z-index: 99999991 !important;
-}
+
 
 .url_text {
   color: @grayDark;
@@ -345,16 +341,6 @@ textarea {
 
 .url_text:hover {
   color: @purple;
-}
-
-.ivu-modal-header-inner {
-  font-size: 20px !important;
-  padding: 20px 30px !important;
-
-}
-
-.ivu-modal-body {
-  padding: 20px 50px !important;
 }
 
 .justify_text {
@@ -370,16 +356,6 @@ textarea {
 
 .url_text:hover {
   color: @purple;
-}
-
-.ivu-modal-header-inner {
-  font-size: 20px !important;
-  padding: 20px 30px !important;
-
-}
-
-.ivu-modal-body {
-  padding: 20px 50px !important;
 }
 
 .justify_text {

--- a/src/views/resources/css/modals.less
+++ b/src/views/resources/css/modals.less
@@ -1,3 +1,4 @@
+@import "./variables.less";
 .modal-container {
   .ivu-modal {
     width: unset !important;
@@ -19,4 +20,14 @@
   .float-right {
     float: right;
   }
+}
+.ivu-modal-header-inner {
+  overflow: unset;
+  font-size: @normalFont;
+  padding: .1rem 0;
+  height: unset;
+}
+
+.ivu-modal-body {
+  padding: .2rem .3rem;
 }


### PR DESCRIPTION
Add the functions in the upper right corner of the page  
  *The previous toggle in upper right has been removed.
  *Add the display of profile info in the upper right corner
  *Extracted the Change password feature ,and put it into upper right corner.
  *Extracted the Add account feature  and put it in  upper right corner.
  *Extracted the Backup current mnemonic feature  and put it in  upper right corner.
  *Changed the Setting position and modified  into modal.
Add the tabs of side component which the iview doesn't have.Usage is the same as iview.
Improve the style of modal title.