### PR TITLE
Cache by Generation Hash

### DIFF
--- a/__tests__/database/backends/NetworkBasedObjectStorage.spec.ts
+++ b/__tests__/database/backends/NetworkBasedObjectStorage.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 NEM Foundation (https://nem.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+import {NetworkBasedObjectStorage} from '@/core/database/backends/NetworkBasedObjectStorage'
+
+const getStorage = () => new NetworkBasedObjectStorage<number>('SomeStorageKey')
+
+describe('database/NetworkBasedObjectStorage.spec ==>', () => {
+  describe('constructor() should', () => {
+    test('create instance given no data', () => {
+      const storage = getStorage()
+      expect(storage).toBeDefined()
+    })
+
+    test('Get/Set/Delete same generation hash', () => {
+      const storage = getStorage()
+      const generationHash = 'abc'
+      expect(storage.get(generationHash)).toBeUndefined()
+      storage.set(generationHash, 123)
+      expect(storage.get(generationHash)).toBe(123)
+      storage.set(generationHash, 456)
+      expect(storage.get(generationHash)).toBe(456)
+      storage.remove(generationHash)
+      storage.remove(generationHash)
+      storage.remove(generationHash)
+      expect(storage.get(generationHash)).toBeUndefined()
+    })
+  })
+
+  test('Get/Set/Delete same generation hash different generation hash', () => {
+    const storage = getStorage()
+    const generationHash1 = 'abc1'
+    const generationHash2 = 'abc2'
+    expect(storage.get(generationHash1)).toBeUndefined()
+    expect(storage.get(generationHash2)).toBeUndefined()
+    storage.set(generationHash1, 123)
+    expect(storage.getLatest()).toBe(123)
+    expect(storage.get(generationHash1)).toBe(123)
+    storage.set(generationHash2, 345)
+    expect(storage.getLatest()).toBe(345)
+
+    expect(storage.get(generationHash2)).toBe(345)
+    expect(storage.get(generationHash1)).toBe(123)
+    storage.set(generationHash1, 456)
+    expect(storage.getLatest()).toBe(456)
+    expect(storage.get(generationHash1)).toBe(456)
+    storage.remove(generationHash1)
+    storage.remove(generationHash1)
+    storage.remove(generationHash1)
+    expect(storage.get(generationHash1)).toBeUndefined()
+
+    storage.set(generationHash2, 456)
+    expect(storage.get(generationHash2)).toBe(456)
+    storage.remove(generationHash2)
+    storage.remove(generationHash2)
+    storage.remove(generationHash2)
+    expect(storage.get(generationHash2)).toBeUndefined()
+
+  })
+})

--- a/__tests__/database/backends/NetworkBasedObjectStorage.spec.ts
+++ b/__tests__/database/backends/NetworkBasedObjectStorage.spec.ts
@@ -14,6 +14,7 @@
  *
  */
 import {NetworkBasedObjectStorage} from '@/core/database/backends/NetworkBasedObjectStorage'
+import {timeout} from 'rxjs/operators'
 
 const getStorage = () => new NetworkBasedObjectStorage<number>('SomeStorageKey')
 
@@ -39,21 +40,29 @@ describe('database/NetworkBasedObjectStorage.spec ==>', () => {
     })
   })
 
-  test('Get/Set/Delete same generation hash different generation hash', () => {
+  function delay(ms: number) {
+    return new Promise( resolve => setTimeout(resolve, ms) );
+  }
+
+  test('Get/Set/Delete same generation hash different generation hash', async () => {
     const storage = getStorage()
     const generationHash1 = 'abc1'
     const generationHash2 = 'abc2'
     expect(storage.get(generationHash1)).toBeUndefined()
     expect(storage.get(generationHash2)).toBeUndefined()
     storage.set(generationHash1, 123)
+    await delay(1)
     expect(storage.getLatest()).toBe(123)
     expect(storage.get(generationHash1)).toBe(123)
     storage.set(generationHash2, 345)
+
+    await delay(1)
     expect(storage.getLatest()).toBe(345)
 
     expect(storage.get(generationHash2)).toBe(345)
     expect(storage.get(generationHash1)).toBe(123)
     storage.set(generationHash1, 456)
+    await delay(1)
     expect(storage.getLatest()).toBe(456)
     expect(storage.get(generationHash1)).toBe(456)
     storage.remove(generationHash1)
@@ -62,6 +71,7 @@ describe('database/NetworkBasedObjectStorage.spec ==>', () => {
     expect(storage.get(generationHash1)).toBeUndefined()
 
     storage.set(generationHash2, 456)
+    await delay(1)
     expect(storage.get(generationHash2)).toBe(456)
     storage.remove(generationHash2)
     storage.remove(generationHash2)

--- a/__tests__/database/backends/NetworkBasedObjectStorage.spec.ts
+++ b/__tests__/database/backends/NetworkBasedObjectStorage.spec.ts
@@ -14,7 +14,6 @@
  *
  */
 import {NetworkBasedObjectStorage} from '@/core/database/backends/NetworkBasedObjectStorage'
-import {timeout} from 'rxjs/operators'
 
 const getStorage = () => new NetworkBasedObjectStorage<number>('SomeStorageKey')
 
@@ -41,7 +40,7 @@ describe('database/NetworkBasedObjectStorage.spec ==>', () => {
   })
 
   function delay(ms: number) {
-    return new Promise( resolve => setTimeout(resolve, ms) );
+    return new Promise( resolve => setTimeout(resolve, ms) )
   }
 
   test('Get/Set/Delete same generation hash different generation hash', async () => {

--- a/__tests__/e2e/MosaicServiceIntegrationTest.spec.ts
+++ b/__tests__/e2e/MosaicServiceIntegrationTest.spec.ts
@@ -29,32 +29,38 @@ const realRepositoryFactory = new RepositoryFactoryHttp(realUrl)
 
 describe.skip('services/MosaicService', () => {
   test('getMosaics all addresses', async () => {
+    const generationHash = await realRepositoryFactory.getGenerationHash().toPromise()
     const {networkCurrency} = await mosaicService.getNetworkCurrencies(
-      realRepositoryFactory, networkConfig.networkConfigurationDefaults,
+      realRepositoryFactory, generationHash, networkConfig.networkConfigurationDefaults,
     ).toPromise()
     const addresses: Address[] = [ address1, address2, address3, address4, address5 ]
     const accountInfos = await realRepositoryFactory.createAccountRepository().getAccountsInfo(addresses).toPromise()
-    const result = await mosaicService.getMosaics(realRepositoryFactory, networkCurrency, accountInfos).toPromise()
+    const result = await mosaicService.getMosaics(realRepositoryFactory, generationHash, networkCurrency,
+      accountInfos).toPromise()
     console.log(JSON.stringify(result, null, 2))
   })
 
   test('getMosaics account 1 addresses', async () => {
+    const generationHash = await realRepositoryFactory.getGenerationHash().toPromise()
     const {networkCurrency} = await mosaicService.getNetworkCurrencies(
-      realRepositoryFactory, networkConfig.networkConfigurationDefaults,
+      realRepositoryFactory, generationHash, networkConfig.networkConfigurationDefaults,
     ).toPromise()
     const addresses: Address[] = [address1]
     const accountInfos = await realRepositoryFactory.createAccountRepository().getAccountsInfo(addresses).toPromise()
-    const result = await mosaicService.getMosaics(realRepositoryFactory, networkCurrency, accountInfos).toPromise()
+    const result = await mosaicService.getMosaics(realRepositoryFactory, generationHash, networkCurrency,
+      accountInfos).toPromise()
     console.log(JSON.stringify(result, null, 2))
   })
 
   test('getMosaics account 3 addresses', async () => {
+    const generationHash = await realRepositoryFactory.getGenerationHash().toPromise()
     const {networkCurrency} = await mosaicService.getNetworkCurrencies(
-      realRepositoryFactory, networkConfig.networkConfigurationDefaults,
+      realRepositoryFactory, generationHash, networkConfig.networkConfigurationDefaults,
     ).toPromise()
     const addresses: Address[] = [address3]
     const accountInfos = await realRepositoryFactory.createAccountRepository().getAccountsInfo(addresses).toPromise()
-    const result = await mosaicService.getMosaics(realRepositoryFactory, networkCurrency, accountInfos).toPromise()
+    const result = await mosaicService.getMosaics(realRepositoryFactory, generationHash, networkCurrency,
+      accountInfos).toPromise()
     console.log(JSON.stringify(result, null, 2))
   })
 })

--- a/config/network.conf.json
+++ b/config/network.conf.json
@@ -17,8 +17,8 @@
     "maxCosignedAccountsPerAccount": 25,
     "maxMessageSize": 1024,
     "maxMosaicAtomicUnits":  9000000000000000,
-    "currencyMosaicId": "747B276C30626442",
-    "harvestingMosaicId": "747B276C30626442"
+    "currencyMosaicId": "519FC24B9223E0B4",
+    "harvestingMosaicId": "519FC24B9223E0B4"
   },
   "nodes": [
     {"friendlyName": "API EU West 1", "roles": 2, "url":"http://api-01.eu-west-1.0941-v1.symboldev.network:3000"},

--- a/src/components/TransactionList/TransactionTable/TransactionTable.vue
+++ b/src/components/TransactionList/TransactionTable/TransactionTable.vue
@@ -8,8 +8,8 @@
     <div v-if="transactions.length" class="transaction-rows-outer-container">
       <div class="transaction-rows-inner-container">
         <TransactionRow
-          v-for="transaction in transactions"
-          :key="transaction.transactionInfo.hash"
+          v-for="(transaction, index) in transactions"
+          :key="index"
           :transaction="transaction"
           :is-partial="getTransactionStatus(transaction) === 'partial'"
           @click="$emit('click', transaction)"

--- a/src/core/database/backends/NetworkBasedObjectStorage.ts
+++ b/src/core/database/backends/NetworkBasedObjectStorage.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 NEM Foundation (https://nem.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+import {SimpleObjectStorage} from '@/core/database/backends/SimpleObjectStorage'
+import {NetworkBasedModel} from '@/core/database/entities/NetworkBasedModel'
+
+/**
+ * A storage save the data per generation hash
+ */
+export class NetworkBasedObjectStorage<E> {
+
+  private readonly storage: SimpleObjectStorage<Record<string, NetworkBasedModel<E>>>
+
+  public constructor(storageKey: string) {
+    this.storage = new SimpleObjectStorage<Record<string, NetworkBasedModel<E>>>(storageKey)
+  }
+
+  /**
+   * it gets the stored value for the specific generation hash.
+   *
+   * @param generationHash the generation hash
+   * @return the stored value for the provided network hash or undefined
+   */
+  public get(generationHash: string): E | undefined {
+    const map = this.storage.get() || {}
+    return map[generationHash] && map[generationHash].data || undefined
+  }
+
+  /**
+   * It gets the latest stored entry according to the timestamp.
+   * @return the entry if available.
+   */
+  public getLatest(): E | undefined {
+    const map = this.storage.get() || {}
+    const latest = Object.values(map).reduce(function (prev, current) {
+      return (prev && prev.timestamp > current.timestamp) ? prev : current
+    }, undefined)
+    return latest && latest.data || undefined
+  }
+
+  /**
+   * Stores the value for the provided generation hash.
+   *
+   * @param generationHash the generation hash
+   * @param value to be stored
+   */
+  public set(generationHash: string, value: E): void {
+    const map = this.storage.get() || {}
+    map[generationHash] = new NetworkBasedModel(generationHash, value)
+    this.storage.set(map)
+  }
+
+  /**
+   * Deletes the stored value for the given generation hash
+   * @param generationHash the generation hash.
+   */
+  public remove(generationHash: string): void {
+    const map = this.storage.get() || {}
+    delete map[generationHash]
+    this.storage.set(map)
+  }
+
+}

--- a/src/core/database/entities/NetworkBasedModel.ts
+++ b/src/core/database/entities/NetworkBasedModel.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 NEM Foundation (https://nem.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+/**
+ * A model that store some generic value based on the generation hash.
+ */
+export class NetworkBasedModel<E> {
+
+  public readonly timestamp = Date.now()
+
+  constructor(public readonly generationHash: string, public readonly data: E) {
+
+  }
+}

--- a/src/services/MosaicService.ts
+++ b/src/services/MosaicService.ts
@@ -28,6 +28,7 @@ import {ObservableHelpers} from '@/core/utils/ObservableHelpers'
 import {SimpleObjectStorage} from '@/core/database/backends/SimpleObjectStorage'
 import {TimeHelpers} from '@/core/utils/TimeHelpers'
 import {NetworkConfigurationModel} from '@/core/database/entities/NetworkConfigurationModel'
+import {NetworkBasedObjectStorage} from '@/core/database/backends/NetworkBasedObjectStorage'
 
 // custom types
 export type ExpirationStatus = 'unlimited' | 'expired' | string | number
@@ -65,7 +66,7 @@ export class MosaicService {
   /**
    * Store that caches the mosaic information of the current accounts when returned from rest.
    */
-  private readonly mosaicDataStorage = new SimpleObjectStorage<MosaicModel[]>('mosaicData')
+  private readonly mosaicDataStorage = new NetworkBasedObjectStorage<MosaicModel[]>('mosaicCache')
 
   /**
    * The storage to keep user configuration around mosaics.  For example, the balance hidden
@@ -77,8 +78,7 @@ export class MosaicService {
   /**
    * Store that caches the information around the network currency.
    */
-  private readonly networkCurrencyStorage = new SimpleObjectStorage<NetworkCurrencyStorage>(
-    'networkCurrencyStorage')
+  private readonly networkCurrencyStorage = new NetworkBasedObjectStorage<NetworkCurrencyStorage>('networkCurrencyCache')
 
   /**
    * This method loads and caches the mosaic information for the given accounts.
@@ -92,10 +92,11 @@ export class MosaicService {
    */
   public getMosaics(
     repositoryFactory: RepositoryFactory,
+    generationHash: string,
     networkCurrency: NetworkCurrencyModel,
     accountsInfo: AccountInfo[],
   ): Observable<MosaicModel[]> {
-    const mosaicDataList = this.loadMosaicData()
+    const mosaicDataList = this.loadMosaicData(generationHash) || []
     const resolvedBalancesObservable = this.resolveBalances(repositoryFactory, accountsInfo)
     const accountAddresses = accountsInfo.map(a => a.address)
     const mosaicsFromAccountsObservable = repositoryFactory.createMosaicRepository()
@@ -109,7 +110,7 @@ export class MosaicService {
         return combineLatest([ nameObservables, mosaicInfoObservable ]).pipe(map(([ names, mosaicInfos ]) => {
           return this.toMosaicDtos(balances, mosaicInfos, names, networkCurrency, accountAddresses)
         }))
-      })).pipe(tap((d) => this.saveMosaicData(d)),
+      })).pipe(tap((d) => this.saveMosaicData(generationHash, d)),
         ObservableHelpers.defaultFirst(mosaicDataList))
   }
 
@@ -182,15 +183,16 @@ export class MosaicService {
    * and harvest currencies (cat.harvest) returned by the network configuration endpoint.
    *
    * @param {RepositoryFactory} repositoryFactory
+   * @param {generationHash} the generation hash.
    * @param {NetworkConfigurationModel} networkConfig
    * @returns {Observable<NetworkCurrencyModel[]>}
    */
-  // TODO move this to a service in the SDK.
   public getNetworkCurrencies(
     repositoryFactory: RepositoryFactory,
+    generationHash: string,
     networkConfig: NetworkConfigurationModel,
   ): Observable<NetworkCurrencyStorage> {
-    const storedNetworkCurrencies = this.networkCurrencyStorage.get()
+    const storedNetworkCurrencies = this.networkCurrencyStorage.get(generationHash)
     const mosaicHttp = repositoryFactory.createMosaicRepository()
     const namespaceHttp = repositoryFactory.createNamespaceRepository()
 
@@ -218,22 +220,22 @@ export class MosaicService {
         networkCurrency: networkMosaics[0],
         harvestCurrency: networkMosaics[1] || networkMosaics[0],
       })),
-      tap(d => this.networkCurrencyStorage.set(d)),
+      tap(d => this.networkCurrencyStorage.set(generationHash, d)),
       ObservableHelpers.defaultFirst(storedNetworkCurrencies),
     )
   }
 
-  private loadMosaicData(): MosaicModel[] {
-    return this.mosaicDataStorage.get()
+  private loadMosaicData(generationHash: string): MosaicModel[] {
+    return this.mosaicDataStorage.get(generationHash)
   }
 
-  private saveMosaicData(mosaics: MosaicModel[]) {
-    this.mosaicDataStorage.set(mosaics)
+  private saveMosaicData(generationHash: string, mosaics: MosaicModel[]) {
+    this.mosaicDataStorage.set(generationHash, mosaics)
   }
 
-  public reset() {
-    this.mosaicDataStorage.remove()
-    this.networkCurrencyStorage.remove()
+  public reset(generationHash: string) {
+    this.mosaicDataStorage.remove(generationHash)
+    this.networkCurrencyStorage.remove(generationHash)
   }
 
   /**

--- a/src/services/MosaicService.ts
+++ b/src/services/MosaicService.ts
@@ -43,7 +43,7 @@ export interface AttachedMosaic {
   amount: number
 }
 
-interface NetworkCurrencyStorage {
+interface NetworkCurrenciesModel {
   networkCurrency: NetworkCurrencyModel
   harvestCurrency: NetworkCurrencyModel
 }
@@ -78,7 +78,7 @@ export class MosaicService {
   /**
    * Store that caches the information around the network currency.
    */
-  private readonly networkCurrencyStorage = new NetworkBasedObjectStorage<NetworkCurrencyStorage>('networkCurrencyCache')
+  private readonly networkCurrencyStorage = new NetworkBasedObjectStorage<NetworkCurrenciesModel>('networkCurrencyCache')
 
   /**
    * This method loads and caches the mosaic information for the given accounts.
@@ -86,6 +86,7 @@ export class MosaicService {
    * information (if possible).
    *
    * @param {RepositoryFactory} repositoryFactory
+   * @param {string} generationHash
    * @param {NetworkCurrencyModel} networkCurrency
    * @param {AccountInfo[]} accountsInfo
    * @returns {Observable<MosaicModel[]>}
@@ -191,7 +192,7 @@ export class MosaicService {
     repositoryFactory: RepositoryFactory,
     generationHash: string,
     networkConfig: NetworkConfigurationModel,
-  ): Observable<NetworkCurrencyStorage> {
+  ): Observable<NetworkCurrenciesModel> {
     const storedNetworkCurrencies = this.networkCurrencyStorage.get(generationHash)
     const mosaicHttp = repositoryFactory.createMosaicRepository()
     const namespaceHttp = repositoryFactory.createNamespaceRepository()

--- a/src/services/NetworkService.ts
+++ b/src/services/NetworkService.ts
@@ -22,12 +22,12 @@ import {catchError, concatMap, flatMap, map, take, tap} from 'rxjs/operators'
 import * as _ from 'lodash'
 
 import {ObservableHelpers} from '@/core/utils/ObservableHelpers'
-import {SimpleObjectStorage} from '@/core/database/backends/SimpleObjectStorage'
 
 import networkConfig from '../../config/network.conf.json'
 import {fromIterable} from 'rxjs/internal-compatibility'
 import {NetworkConfigurationModel} from '@/core/database/entities/NetworkConfigurationModel'
 import {NetworkConfigurationHelpers} from '@/core/utils/NetworkConfigurationHelpers'
+import {NetworkBasedObjectStorage} from '@/core/database/backends/NetworkBasedObjectStorage'
 
 /**
  * The service in charge of loading and caching anything related to Network from Rest.
@@ -37,13 +37,13 @@ export class NetworkService {
   /**
    * The network information local cache.
    */
-  private readonly storage = new SimpleObjectStorage<NetworkModel>('network')
+  private readonly storage = new NetworkBasedObjectStorage<NetworkModel>('networkCache')
 
   /**
    * The best default Url. It uses the stored condiguration if possible.
    */
   public getDefaultUrl(): string {
-    const storedNetworkModel = this.loadNetworkModel()
+    const storedNetworkModel = this.storage.getLatest()
     return URLHelpers.formatUrl(
       storedNetworkModel && storedNetworkModel.url || networkConfig.defaultNodeUrl).url
   }
@@ -56,32 +56,34 @@ export class NetworkService {
    */
   public getNetworkModel(candidateUrl: string | undefined):
   Observable<{ fallback: boolean, networkModel: NetworkModel, repositoryFactory: RepositoryFactory }> {
-    const storedNetworkModel = this.loadNetworkModel()
-    const possibleUrls = this.resolveCandidates(candidateUrl, storedNetworkModel)
-
+    const possibleUrls = this.resolveCandidates(candidateUrl, this.storage.getLatest())
     const repositoryFactoryObservable = fromIterable(possibleUrls)
       .pipe(concatMap(url => this.createRepositoryFactory(url)))
       .pipe(take(1))
     return repositoryFactoryObservable.pipe(flatMap(({url, repositoryFactory}) => {
-      const networkRepository = repositoryFactory.createNetworkRepository()
-      const nodeRepository = repositoryFactory.createNodeRepository()
-      return combineLatest([
-        repositoryFactory.getNetworkType().pipe(ObservableHelpers.defaultLast(
-          storedNetworkModel && storedNetworkModel.networkType || networkConfig.defaultNetworkType)),
-        repositoryFactory.getGenerationHash().pipe(ObservableHelpers.defaultLast(
-          storedNetworkModel && storedNetworkModel.generationHash)),
-        networkRepository.getNetworkProperties().pipe(map(d => this.toNetworkConfigurationModel(d)),
-          ObservableHelpers.defaultLast(
-            storedNetworkModel && storedNetworkModel.networkConfiguration)),
-        nodeRepository.getNodeInfo().pipe(ObservableHelpers.defaultLast(
-          storedNetworkModel && storedNetworkModel.nodeInfo)),
-      ]).pipe(map(restData => {
-        return {
-          fallback: !!candidateUrl && candidateUrl !== url,
-          networkModel: new NetworkModel(url, restData[0], restData[1], restData[2], restData[3]),
-          repositoryFactory,
-        }
-      }), tap(p => this.saveNetworkModel(p.networkModel)))
+      return repositoryFactory.getGenerationHash().pipe(flatMap((generationHash => {
+        const storedNetworkModel = this.storage.get(generationHash)
+        const networkRepository = repositoryFactory.createNetworkRepository()
+        const nodeRepository = repositoryFactory.createNodeRepository()
+        return combineLatest([
+          repositoryFactory.getNetworkType().pipe(ObservableHelpers.defaultLast(
+            storedNetworkModel && storedNetworkModel.networkType || networkConfig.defaultNetworkType)),
+          repositoryFactory.getGenerationHash().pipe(ObservableHelpers.defaultLast(
+            storedNetworkModel && storedNetworkModel.generationHash)),
+          networkRepository.getNetworkProperties().pipe(map(d => this.toNetworkConfigurationModel(d)),
+            ObservableHelpers.defaultLast(
+              storedNetworkModel && storedNetworkModel.networkConfiguration)),
+          nodeRepository.getNodeInfo().pipe(ObservableHelpers.defaultLast(
+            storedNetworkModel && storedNetworkModel.nodeInfo)),
+        ]).pipe(map(restData => {
+          return {
+            fallback: !!candidateUrl && candidateUrl !== url,
+            networkModel: new NetworkModel(url, restData[0], restData[1], restData[2], restData[3]),
+            repositoryFactory,
+          }
+        }), tap(p => this.storage.set(generationHash, p.networkModel)))
+      })))
+
     }))
   }
 
@@ -132,17 +134,8 @@ export class NetworkService {
         ...networkConfig.nodes.map(n => n.url) ].filter(p => p))
   }
 
-
-  private loadNetworkModel(): NetworkModel | undefined {
-    return this.storage.get()
-  }
-
-  private saveNetworkModel(networkModel: NetworkModel) {
-    this.storage.set(networkModel)
-  }
-
-  public reset() {
-    this.storage.remove()
+  public reset(generationHash: string) {
+    this.storage.remove(generationHash)
   }
 
   /**

--- a/src/services/NodeService.ts
+++ b/src/services/NodeService.ts
@@ -14,7 +14,7 @@
  *
  */
 
-import {RepositoryFactory, NodeInfo} from 'symbol-sdk'
+import {NodeInfo, RepositoryFactory} from 'symbol-sdk'
 import {Observable} from 'rxjs'
 import {ObservableHelpers} from '@/core/utils/ObservableHelpers'
 import {map, tap} from 'rxjs/operators'

--- a/src/store/Mosaic.ts
+++ b/src/store/Mosaic.ts
@@ -117,8 +117,9 @@ export default {
         const repositoryFactory = rootGetters['network/repositoryFactory']
         const mosaicService = new MosaicService()
         const networkConfig = rootGetters['network/networkConfiguration']
+        const generationHash = rootGetters['network/generationHash']
 
-        mosaicService.getNetworkCurrencies(repositoryFactory, networkConfig)
+        mosaicService.getNetworkCurrencies(repositoryFactory, generationHash, networkConfig)
           .subscribe(networkCurrencies => {
             commit('networkCurrency', networkCurrencies.networkCurrency)
             commit('setInitialized', true)
@@ -139,9 +140,11 @@ export default {
       const repositoryFactory: RepositoryFactory = rootGetters['network/repositoryFactory']
       const networkCurrency: NetworkCurrencyModel = rootGetters['mosaic/networkCurrency']
       const accountsInfo: AccountInfo[] = rootGetters['wallet/accountsInfo'] || []
+      const generationHash = rootGetters['network/generationHash']
 
       new MosaicService().getMosaics(
         repositoryFactory,
+        generationHash,
         networkCurrency,
         accountsInfo,
       ).subscribe((mosaics) => {
@@ -149,6 +152,11 @@ export default {
         if (!currentSignerAddress) return
         commit('mosaics', {mosaics: mosaics, currentSignerAddress, networkCurrency})
       })
+    },
+
+    RESET_MOSAICS({commit, rootGetters}) {
+      const networkCurrency: NetworkCurrencyModel = rootGetters['mosaic/networkCurrency']
+      commit('mosaics', {mosaics: [], undefined, networkCurrency})
     },
 
     SIGNER_CHANGED({commit, rootGetters, getters}) {

--- a/src/store/Namespace.ts
+++ b/src/store/Namespace.ts
@@ -75,14 +75,20 @@ export default {
     LOAD_NAMESPACES({commit, rootGetters}) {
       const knownAddresses: Address[] = rootGetters['wallet/knownAddresses'] || []
       const repositoryFactory = rootGetters['network/repositoryFactory']
+      const generationHash = rootGetters['network/generationHash']
       const namespaceService = new NamespaceService()
-      namespaceService.getNamespaces(repositoryFactory, knownAddresses).subscribe((namespaces) => {
+      namespaceService.getNamespaces(repositoryFactory, generationHash, knownAddresses).subscribe((namespaces) => {
         const currentSignerAddress: Address = rootGetters['wallet/currentSignerAddress']
         if (!currentSignerAddress) {
           return
         }
         commit('namespaces', {namespaces, currentSignerAddress})
       })
+    },
+
+    RESET_NAMESPACES({commit}) {
+      const namespaces: NamespaceModel[] = []
+      commit('namespaces', {namespaces, undefined})
     },
 
     SIGNER_CHANGED({commit, rootGetters, getters}) {

--- a/src/store/Network.ts
+++ b/src/store/Network.ts
@@ -170,14 +170,14 @@ export default {
     },
 
 
-    async CONNECT({commit, dispatch}, newCandidate: string | undefined) {
+    async CONNECT({commit, dispatch, getters}, newCandidate: string | undefined) {
       const networkService = new NetworkService()
       const {networkModel, repositoryFactory, fallback} = await networkService.getNetworkModel(newCandidate)
         .toPromise()
       if (fallback) {
         throw new Error('Connection Error.')
       }
-
+      const oldGenerationHash = getters['generationHash']
       const getNodesPromise = new NodeService().getNodes(repositoryFactory, networkModel.url).toPromise()
       const getBlockchainHeightPromise = repositoryFactory.createChainRepository()
         .getBlockchainHeight().toPromise()
@@ -201,6 +201,10 @@ export default {
       $eventBus.$emit('newConnection', currentPeer)
       // subscribe to updates
       dispatch('SUBSCRIBE')
+      if (oldGenerationHash != networkModel.generationHash) {
+        dispatch('wallet/NETWORK_CHANGED', {}, {root: true})
+        dispatch('statistics/LOAD', {}, {root: true})
+      }
     },
 
 
@@ -256,13 +260,13 @@ export default {
       commit('removePeer', peerUrl)
     },
 
-    async RESET_PEERS({dispatch}) {
+    async RESET_PEERS({dispatch, getters}) {
 
       const nodeService = new NodeService()
       nodeService.reset()
 
       const networkService = new NetworkService()
-      networkService.reset()
+      networkService.reset(getters['generationHash'])
 
       dispatch('SET_CURRENT_PEER', networkService.getDefaultUrl())
 

--- a/src/store/Statistics.ts
+++ b/src/store/Statistics.ts
@@ -44,22 +44,10 @@ export default {
     countNodes: (state, cnt) => Vue.set(state, 'countNodes', cnt),
   },
   actions: {
-    async initialize({commit, getters, rootGetters}) {
+    async initialize({commit, getters, dispatch}) {
       const callback = async () => {
-        const repositoryFactory = rootGetters['network/repositoryFactory'] as RepositoryFactory
-        const nodeHttp = repositoryFactory.createNodeRepository()
-        const storageInfoPromise = nodeHttp.getStorageInfo().toPromise()
-        const nodePeersPromise = nodeHttp.getNodePeers().toPromise()
 
-        const diagnostic: StorageInfo = await storageInfoPromise
-        const nodes = await nodePeersPromise
-
-        commit('countTransactions', diagnostic.numTransactions)
-        commit('countBlocks', diagnostic.numBlocks)
-        commit('countAccounts', diagnostic.numAccounts)
-
-        commit('countNodes', nodes.length)
-
+        dispatch('LOAD')
         // update store
         commit('setInitialized', true)
       }
@@ -73,5 +61,27 @@ export default {
       }
       await Lock.uninitialize(callback, {getters})
     },
+
+    async LOAD({commit, rootGetters}){
+
+      commit('countTransactions',0)
+      commit('countBlocks', 0)
+      commit('countAccounts', 0)
+      commit('countNodes', 0)
+
+      const repositoryFactory = rootGetters['network/repositoryFactory'] as RepositoryFactory
+      const nodeHttp = repositoryFactory.createNodeRepository()
+      const storageInfoPromise = nodeHttp.getStorageInfo().toPromise()
+      const nodePeersPromise = nodeHttp.getNodePeers().toPromise()
+
+      const diagnostic: StorageInfo = await storageInfoPromise
+      const nodes = await nodePeersPromise
+
+      commit('countTransactions', diagnostic.numTransactions)
+      commit('countBlocks', diagnostic.numBlocks)
+      commit('countAccounts', diagnostic.numAccounts)
+      commit('countNodes', nodes.length)
+    },
+
   },
 }

--- a/src/store/Transaction.ts
+++ b/src/store/Transaction.ts
@@ -156,16 +156,16 @@ export default {
       commit('isFetchingTransactions', true)
 
       const queryParams = new QueryParams({pageSize: 100})
-      if (group === TransactionGroup.all || group === TransactionGroup.confirmed) {
+      if (group == undefined || group === TransactionGroup.all || group === TransactionGroup.confirmed) {
         subscriptions.push(subscribeTransactions(TransactionGroup.confirmed,
           accountRepository.getAccountTransactions(currentSignerAddress, queryParams)))
       }
-      if (group === TransactionGroup.all || group === TransactionGroup.unconfirmed) {
+      if (group == undefined || group === TransactionGroup.all || group === TransactionGroup.unconfirmed) {
         subscriptions.push(subscribeTransactions(TransactionGroup.unconfirmed,
           accountRepository.getAccountUnconfirmedTransactions(currentSignerAddress, queryParams)))
       }
 
-      if (group === TransactionGroup.all || group === TransactionGroup.partial) {
+      if (group == undefined || group === TransactionGroup.all || group === TransactionGroup.partial) {
         subscriptions.push(subscribeTransactions(TransactionGroup.partial,
           accountRepository.getAccountPartialTransactions(currentSignerAddress, queryParams)))
       }

--- a/src/store/Wallet.ts
+++ b/src/store/Wallet.ts
@@ -258,6 +258,7 @@ export default {
         {root: true})
       commit('currentWallet', null)
       commit('currentWalletAddress', null)
+      commit('currentSignerAddress', null)
     },
 
     async SET_CURRENT_SIGNER({commit, dispatch, getters, rootGetters},

--- a/src/store/Wallet.ts
+++ b/src/store/Wallet.ts
@@ -300,6 +300,16 @@ export default {
 
     },
 
+    async NETWORK_CHANGED({dispatch}) {
+      dispatch('transaction/RESET_TRANSACTIONS', {}, {root: true})
+      dispatch('namespace/RESET_NAMESPACES', {}, {root: true})
+      dispatch('mosaic/RESET_MOSAICS', {}, {root: true})
+      dispatch('transaction/LOAD_TRANSACTIONS', undefined, {root: true})
+      await dispatch('LOAD_ACCOUNT_INFO')
+      dispatch('namespace/LOAD_NAMESPACES', {}, {root: true})
+      dispatch('mosaic/LOAD_MOSAICS', {}, {root: true})
+    },
+
     async LOAD_ACCOUNT_INFO({commit, getters, rootGetters}) {
       const networkType: NetworkType = rootGetters['network/networkType']
       const currentWallet: WalletModel = getters.currentWallet

--- a/src/store/Wallet.ts
+++ b/src/store/Wallet.ts
@@ -307,6 +307,7 @@ export default {
       dispatch('transaction/LOAD_TRANSACTIONS', undefined, {root: true})
       await dispatch('LOAD_ACCOUNT_INFO')
       dispatch('namespace/LOAD_NAMESPACES', {}, {root: true})
+      await dispatch('mosaic/LOAD_NETWORK_CURRENCIES', undefined, {root: true})
       dispatch('mosaic/LOAD_MOSAICS', {}, {root: true})
     },
 

--- a/src/views/pages/accounts/LoginPageTs.ts
+++ b/src/views/pages/accounts/LoginPageTs.ts
@@ -168,8 +168,7 @@ export default class LoginPageTs extends Vue {
 
     // if account doesn't exist, authentication is not valid
     if (!account) {
-      this.$store.dispatch('diagnostic/ADD_ERROR', 'Invalid login attempt')
-      return this.$router.push({name: 'accounts.login'})
+      return this.$store.dispatch('notification/ADD_ERROR', 'Invalid login attempt')
     }
 
     // account exists, fetch data


### PR DESCRIPTION
Hey guys, in this PR I add a new storage indirection where the data is split by generation hash/network. The idea is that the data doesn't collide when swapping networks (peer selector). 

I've also added a bit of improvement around the data shown when swapping network, I know this is not really that useful now as we are going to show a big dialog saying you need to login but at least it should not show partial information from different networks in the background.

I've also updated the name of the tables, prefixed with "Cache" when they are caches.

Have a look and let me know