### PR TITLE
Storage Versioning

### DIFF
--- a/__tests__/database/backends/NetworkBasedObjectStorage.spec.ts
+++ b/__tests__/database/backends/NetworkBasedObjectStorage.spec.ts
@@ -14,8 +14,9 @@
  *
  */
 import {NetworkBasedObjectStorage} from '@/core/database/backends/NetworkBasedObjectStorage'
+import {SimpleObjectStorage} from '@/core/database/backends/SimpleObjectStorage'
 
-const getStorage = () => new NetworkBasedObjectStorage<number>('SomeStorageKey')
+const getStorage = () => new NetworkBasedObjectStorage<number>(new SimpleObjectStorage('SomeStorageKey'))
 
 describe('database/NetworkBasedObjectStorage.spec ==>', () => {
   describe('constructor() should', () => {

--- a/__tests__/database/backends/VersionedObjectStorage.spec.ts
+++ b/__tests__/database/backends/VersionedObjectStorage.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 NEM Foundation (https://nem.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+import {Migration, VersionedObjectStorage} from '@/core/database/backends/VersionedObjectStorage'
+
+describe('database/SimpleObjectStorage.spec ==>', () => {
+  describe('constructor() should', () => {
+
+    test('Get/Set/Delete', () => {
+      const storageKey = 'someTable'
+      const storage1 = new VersionedObjectStorage<number>(storageKey)
+      expect(storage1.get()).toBeUndefined()
+      expect(storage1.getVersion()).toBeUndefined()
+      storage1.set(123)
+      expect(storage1.get()).toBe(123)
+      storage1.set(456)
+      expect(storage1.getVersion()).toBe(1)
+      expect(storage1.get()).toBe(456)
+      storage1.remove()
+      expect(storage1.get()).toBeUndefined()
+      expect(storage1.getVersion()).toBeUndefined()
+    })
+
+
+    test('Get/Set/Delete Migration', () => {
+      const storageKey = 'someTable'
+      const storage1 = new VersionedObjectStorage<number>(storageKey)
+      storage1.set(123)
+      expect(storage1.getVersion()).toBe(1)
+      expect(storage1.get()).toBe(123)
+
+      const migration1: Migration = {
+        description: 'toString',
+        migrate(from: any): any {
+          return from.toString()
+        },
+      }
+
+      const migration2: Migration = {
+        description: 'add A',
+        migrate(from: any): any {
+          return from + 'A'
+        },
+      }
+
+      const migration3: Migration = {
+        description: 'add Z',
+        migrate(from: any): any {
+          return from + 'Z'
+        },
+      }
+      // Migrate to string
+      const storage2 = new VersionedObjectStorage<string>(storageKey, [migration1])
+      expect(storage2.get()).toBe('123')
+      expect(storage2.getVersion()).toBe(2)
+
+      // No Migration
+      const storage3 = new VersionedObjectStorage<string>(storageKey, [migration1])
+      expect(storage3.get()).toBe('123')
+      expect(storage3.getVersion()).toBe(2)
+
+      // Double Migration (append A and append Z)
+      const storage4 = new VersionedObjectStorage<string>(storageKey, [ migration1, migration2, migration3 ])
+      expect(storage4.get()).toBe('123AZ')
+      expect(storage4.getVersion()).toBe(4)
+    })
+  })
+
+
+})

--- a/src/components/AccountBalancesPanel/AccountBalancesPanel.vue
+++ b/src/components/AccountBalancesPanel/AccountBalancesPanel.vue
@@ -10,7 +10,7 @@
           'xym-outline': true,
         }"
       >
-        <div class="wallet_address">
+        <div v-if="currentSignerAddress" class="wallet_address">
           <span class="address">
             {{ currentSignerAddress.plain() }}
           </span>

--- a/src/core/database/backends/INetworkBasedStorage.ts
+++ b/src/core/database/backends/INetworkBasedStorage.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 NEM Foundation (https://nem.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+/**
+ * Storage
+ */
+export interface INetworkBasedStorage<E> {
+
+  /**
+   * it gets the stored value for the specific generation hash.
+   *
+   * @param generationHash the generation hash
+   * @return the stored value for the provided network hash or undefined
+   */
+  get(generationHash: string): E | undefined
+
+  /**
+   * It gets the latest stored entry according to the timestamp.
+   * @return the entry if available.
+   */
+  getLatest(): E | undefined
+
+  /**
+   * Stores the value for the provided generation hash.
+   *
+   * @param generationHash the generation hash
+   * @param value to be stored
+   */
+  set(generationHash: string, value: E): void
+
+  /**
+   * Deletes the stored value for the given generation hash
+   * @param generationHash the generation hash.
+   */
+  remove(generationHash: string): void
+
+}

--- a/src/core/database/backends/IStorage.ts
+++ b/src/core/database/backends/IStorage.ts
@@ -13,16 +13,25 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
+
 /**
- * A model that store some generic value based on the generation hash.
+ * Generic interface for simple stored objects.
  */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
+export interface IStorage<E> {
 
-export class NetworkBasedEntryModel<E> {
+  /**
+   * @return the stored value or undefined
+   */
+  get(): E | undefined
 
-  public readonly timestamp = Date.now()
+  /**
+   * Stores the provided value.
+   * @param value to be stored
+   */
+  set(value: E): void
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
-
-  }
+  /**
+   * Deletes the stored value.
+   */
+  remove(): void
 }

--- a/src/core/database/backends/NetworkBasedObjectStorage.ts
+++ b/src/core/database/backends/NetworkBasedObjectStorage.ts
@@ -14,19 +14,18 @@
  *
  */
 
-import {SimpleObjectStorage} from '@/core/database/backends/SimpleObjectStorage'
-import {NetworkBasedModel} from '@/core/database/entities/NetworkBasedModel'
+import {NetworkBasedEntryModel, NetworkBasedModel} from '@/core/database/entities/NetworkBasedModel'
+import {IStorage} from '@/core/database/backends/IStorage'
 
 /**
  * A storage save the data per generation hash
  */
 export class NetworkBasedObjectStorage<E> {
 
-  private readonly storage: SimpleObjectStorage<Record<string, NetworkBasedModel<E>>>
-
-  public constructor(storageKey: string) {
-    this.storage = new SimpleObjectStorage<Record<string, NetworkBasedModel<E>>>(storageKey)
-  }
+  /**
+   * @param delegate the delegate that will store the data that stores the generation model.
+   */
+  public constructor(private readonly delegate: IStorage<NetworkBasedModel<E>>) {}
 
   /**
    * it gets the stored value for the specific generation hash.
@@ -35,7 +34,7 @@ export class NetworkBasedObjectStorage<E> {
    * @return the stored value for the provided network hash or undefined
    */
   public get(generationHash: string): E | undefined {
-    const map = this.storage.get() || {}
+    const map = this.delegate.get() || {}
     return map[generationHash] && map[generationHash].data || undefined
   }
 
@@ -44,10 +43,9 @@ export class NetworkBasedObjectStorage<E> {
    * @return the entry if available.
    */
   public getLatest(): E | undefined {
-    const map = this.storage.get() || {}
-    const latest = Object.values(map).reduce(function (prev, current) {
-      return (prev && prev.timestamp > current.timestamp) ? prev : current
-    }, undefined)
+    const map = this.delegate.get() || {}
+    const latest = Object.values(map).reduce(
+      (prev, current) => (prev && prev.timestamp > current.timestamp) ? prev : current, undefined)
     return latest && latest.data || undefined
   }
 
@@ -58,9 +56,9 @@ export class NetworkBasedObjectStorage<E> {
    * @param value to be stored
    */
   public set(generationHash: string, value: E): void {
-    const map = this.storage.get() || {}
-    map[generationHash] = new NetworkBasedModel(generationHash, value)
-    this.storage.set(map)
+    const map = this.delegate.get() || {}
+    map[generationHash] = new NetworkBasedEntryModel(generationHash, value)
+    this.delegate.set(map)
   }
 
   /**
@@ -68,9 +66,9 @@ export class NetworkBasedObjectStorage<E> {
    * @param generationHash the generation hash.
    */
   public remove(generationHash: string): void {
-    const map = this.storage.get() || {}
+    const map = this.delegate.get() || {}
     delete map[generationHash]
-    this.storage.set(map)
+    this.delegate.set(map)
   }
 
 }

--- a/src/core/database/backends/SimpleObjectStorage.ts
+++ b/src/core/database/backends/SimpleObjectStorage.ts
@@ -14,12 +14,12 @@
  *
  */
 // external dependencies
-import {Convert, SHA3Hasher, Crypto} from 'symbol-sdk'
-
+import {Convert, Crypto, SHA3Hasher} from 'symbol-sdk'
 // internal dependencies
 import {IStorageBackend} from '@/core/database/backends/IStorageBackend'
 import {LocalStorageBackend} from '@/core/database/backends/LocalStorageBackend'
 import {ObjectStorageBackend} from '@/core/database/backends/ObjectStorageBackend'
+import {IStorage} from '@/core/database/backends/IStorage'
 
 
 /**
@@ -29,7 +29,7 @@ import {ObjectStorageBackend} from '@/core/database/backends/ObjectStorageBacken
  * The object could be a simple object, an array or a Map/Record with key->value.
  *
  */
-export class SimpleObjectStorage<E> {
+export class SimpleObjectStorage<E> implements IStorage<E>{
 
   /**
    * The Storage backend, if localStorage is not available the storage will be in memory.

--- a/src/core/database/backends/VersionedNetworkBasedObjectStorage.ts
+++ b/src/core/database/backends/VersionedNetworkBasedObjectStorage.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 NEM Foundation (https://nem.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+import {INetworkBasedStorage} from '@/core/database/backends/INetworkBasedStorage'
+import {NetworkBasedObjectStorage} from '@/core/database/backends/NetworkBasedObjectStorage'
+import {Migration, VersionedObjectStorage} from '@/core/database/backends/VersionedObjectStorage'
+import {NetworkBasedModel} from '@/core/database/entities/NetworkBasedModel'
+
+/**
+ * A storage that wraps the stored model with a {version: n, data:T} object and it handles the migration from old
+ * version to new versions.
+ *
+ */
+export class VersionedNetworkBasedObjectStorage<E> extends NetworkBasedObjectStorage<E>
+  implements INetworkBasedStorage<E> {
+
+  constructor(storageKey: string, migrations: Migration[] = []) {
+    super(new VersionedObjectStorage<NetworkBasedModel<E>>(storageKey, migrations))
+  }
+
+}

--- a/src/core/database/backends/VersionedObjectStorage.ts
+++ b/src/core/database/backends/VersionedObjectStorage.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 NEM Foundation (https://nem.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+import {IStorage} from '@/core/database/backends/IStorage'
+import {VersionedModel} from '@/core/database/entities/VersionedModel'
+import {SimpleObjectStorage} from '@/core/database/backends/SimpleObjectStorage'
+
+/**
+ * The operation to migrate the data.
+ */
+export interface Migration {
+
+  readonly description: string
+
+  migrate(from: any): any
+}
+
+/**
+ * A storage that wraps the stored model with a {version: n, data:T} object and it handles the migration from old
+ * version to new versions.
+ *
+ */
+export class VersionedObjectStorage<E> implements IStorage<E> {
+
+  private readonly delegate: IStorage<VersionedModel<E>>
+
+  private readonly currentVersion: number
+
+  constructor(storageKey: string, migrations: Migration[] = []) {
+    this.delegate = new SimpleObjectStorage<VersionedModel<E>>(storageKey)
+    this.currentVersion = migrations.length + 1
+    const versioned = this.delegate.get()
+    if (!versioned || versioned.version == this.currentVersion) {
+      return
+    }
+    if (versioned.version > this.currentVersion) {
+      throw new Error(`Current data version is ${versioned.version} but higher version is ${this.currentVersion}`)
+    }
+    const value = migrations.slice(versioned.version - 1).reduce((toMigrateData, migration) => {
+      if (toMigrateData === undefined) {
+        console.log(`data to migrate is undefined, ignoring migration ${migration.description}`)
+        return undefined
+      }
+      console.log(`Applying migration ${migration.description}`)
+      return migration.migrate(toMigrateData)
+    }, versioned.data)
+    if (value === undefined) {
+      this.remove()
+    } else {
+      this.set(value)
+    }
+  }
+
+  get(): E | undefined {
+    const versioned = this.delegate.get()
+    return versioned && versioned.data || undefined
+  }
+
+  remove(): void {
+    this.delegate.remove()
+  }
+
+  set(value: E): void {
+    this.delegate.set(new VersionedModel<E>(this.currentVersion, value))
+  }
+
+  getVersion(): E | number {
+    const versioned = this.delegate.get()
+    return versioned && versioned.version || undefined
+  }
+
+}

--- a/src/core/database/entities/NetworkCurrenciesModel.ts
+++ b/src/core/database/entities/NetworkCurrenciesModel.ts
@@ -13,16 +13,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/**
- * A model that store some generic value based on the generation hash.
- */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
 
-export class NetworkBasedEntryModel<E> {
 
-  public readonly timestamp = Date.now()
+import {NetworkCurrencyModel} from '@/core/database/entities/NetworkCurrencyModel'
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
-
-  }
+export class NetworkCurrenciesModel {
+  constructor(public networkCurrency: NetworkCurrencyModel,
+    public harvestCurrency: NetworkCurrencyModel) {}
 }

--- a/src/core/database/entities/VersionedModel.ts
+++ b/src/core/database/entities/VersionedModel.ts
@@ -13,16 +13,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/**
- * A model that store some generic value based on the generation hash.
- */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
 
-export class NetworkBasedEntryModel<E> {
 
-  public readonly timestamp = Date.now()
+export class VersionedModel<T> {
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
+  constructor(
+    public readonly version: number,
+    public readonly data: T,
+  ) {
 
   }
 }

--- a/src/core/database/storage/AccountModelStorage.ts
+++ b/src/core/database/storage/AccountModelStorage.ts
@@ -13,16 +13,18 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/**
- * A model that store some generic value based on the generation hash.
- */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
 
-export class NetworkBasedEntryModel<E> {
+import {VersionedObjectStorage} from '@/core/database/backends/VersionedObjectStorage'
+import {AccountModel} from '@/core/database/entities/AccountModel'
 
-  public readonly timestamp = Date.now()
+export class AccountModelStorage extends VersionedObjectStorage<Record<string, AccountModel>> {
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
+  /**
+   * Singleton instance as we want to run the migration just once
+   */
+  public static INSTANCE = new AccountModelStorage()
 
+  private constructor() {
+    super('accounts')
   }
 }

--- a/src/core/database/storage/MosaicConfigurationModelStorage.ts
+++ b/src/core/database/storage/MosaicConfigurationModelStorage.ts
@@ -13,16 +13,18 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/**
- * A model that store some generic value based on the generation hash.
- */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
 
-export class NetworkBasedEntryModel<E> {
+import {VersionedObjectStorage} from '@/core/database/backends/VersionedObjectStorage'
+import {MosaicConfigurationModel} from '@/core/database/entities/MosaicConfigurationModel'
 
-  public readonly timestamp = Date.now()
+export class MosaicConfigurationModelStorage extends VersionedObjectStorage<Record<string, MosaicConfigurationModel>> {
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
+  /**
+   * Singleton instance as we want to run the migration just once
+   */
+  public static INSTANCE = new MosaicConfigurationModelStorage()
 
+  private constructor() {
+    super('mosaicConfiguration')
   }
 }

--- a/src/core/database/storage/MosaicModelStorage.ts
+++ b/src/core/database/storage/MosaicModelStorage.ts
@@ -13,16 +13,19 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/**
- * A model that store some generic value based on the generation hash.
- */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
 
-export class NetworkBasedEntryModel<E> {
+import {VersionedNetworkBasedObjectStorage} from '@/core/database/backends/VersionedNetworkBasedObjectStorage'
+import {MosaicModel} from '@/core/database/entities/MosaicModel'
 
-  public readonly timestamp = Date.now()
+export class MosaicModelStorage extends VersionedNetworkBasedObjectStorage<MosaicModel[]> {
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
+  /**
+   * Singleton instance as we want to run the migration just once
+   */
+  public static INSTANCE = new MosaicModelStorage()
 
+  private constructor() {
+    super('mosaicCache')
   }
+
 }

--- a/src/core/database/storage/NamespaceModelStorage.ts
+++ b/src/core/database/storage/NamespaceModelStorage.ts
@@ -13,16 +13,19 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/**
- * A model that store some generic value based on the generation hash.
- */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
 
-export class NetworkBasedEntryModel<E> {
+import {VersionedNetworkBasedObjectStorage} from '@/core/database/backends/VersionedNetworkBasedObjectStorage'
+import {NamespaceModel} from '@/core/database/entities/NamespaceModel'
 
-  public readonly timestamp = Date.now()
+export class NamespaceModelStorage extends VersionedNetworkBasedObjectStorage<NamespaceModel[]> {
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
+  /**
+   * Singleton instance as we want to run the migration just once
+   */
+  public static INSTANCE = new NamespaceModelStorage()
 
+  private constructor() {
+    super('namespaceCache')
   }
+
 }

--- a/src/core/database/storage/NetworkCurrenciesModelStorage.ts
+++ b/src/core/database/storage/NetworkCurrenciesModelStorage.ts
@@ -13,16 +13,19 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/**
- * A model that store some generic value based on the generation hash.
- */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
 
-export class NetworkBasedEntryModel<E> {
+import {NetworkCurrenciesModel} from '@/core/database/entities/NetworkCurrenciesModel'
+import {VersionedNetworkBasedObjectStorage} from '@/core/database/backends/VersionedNetworkBasedObjectStorage'
 
-  public readonly timestamp = Date.now()
+export class NetworkCurrenciesModelStorage extends VersionedNetworkBasedObjectStorage<NetworkCurrenciesModel> {
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
+  /**
+   * Singleton instance as we want to run the migration just once
+   */
+  public static INSTANCE = new NetworkCurrenciesModelStorage()
 
+  private constructor() {
+    super('networkCurrencyCache')
   }
+
 }

--- a/src/core/database/storage/NetworkModelStorage.ts
+++ b/src/core/database/storage/NetworkModelStorage.ts
@@ -13,16 +13,19 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/**
- * A model that store some generic value based on the generation hash.
- */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
 
-export class NetworkBasedEntryModel<E> {
+import {VersionedNetworkBasedObjectStorage} from '@/core/database/backends/VersionedNetworkBasedObjectStorage'
+import {NetworkModel} from '@/core/database/entities/NetworkModel'
 
-  public readonly timestamp = Date.now()
+export class NetworkModelStorage extends VersionedNetworkBasedObjectStorage<NetworkModel> {
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
+  /**
+   * Singleton instance as we want to run the migration just once
+   */
+  public static INSTANCE = new NetworkModelStorage()
 
+  private constructor() {
+    super('networkCache')
   }
+
 }

--- a/src/core/database/storage/NodeModelStorage.ts
+++ b/src/core/database/storage/NodeModelStorage.ts
@@ -13,16 +13,18 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/**
- * A model that store some generic value based on the generation hash.
- */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
 
-export class NetworkBasedEntryModel<E> {
+import {VersionedObjectStorage} from '@/core/database/backends/VersionedObjectStorage'
+import {NodeModel} from '@/core/database/entities/NodeModel'
 
-  public readonly timestamp = Date.now()
+export class NodeModelStorage extends VersionedObjectStorage<NodeModel[]> {
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
+  /**
+   * Singleton instance as we want to run the migration just once
+   */
+  public static INSTANCE = new NodeModelStorage()
 
+  private constructor() {
+    super('node')
   }
 }

--- a/src/core/database/storage/SettingsModelStorage.ts
+++ b/src/core/database/storage/SettingsModelStorage.ts
@@ -13,16 +13,18 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/**
- * A model that store some generic value based on the generation hash.
- */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
 
-export class NetworkBasedEntryModel<E> {
+import {VersionedObjectStorage} from '@/core/database/backends/VersionedObjectStorage'
+import {SettingsModel} from '@/core/database/entities/SettingsModel'
 
-  public readonly timestamp = Date.now()
+export class SettingsModelStorage extends VersionedObjectStorage<Record<string, SettingsModel>> {
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
+  /**
+   * Singleton instance as we want to run the migration just once
+   */
+  public static INSTANCE = new SettingsModelStorage()
 
+  private constructor() {
+    super('settings')
   }
 }

--- a/src/core/database/storage/WalletModelStorage.ts
+++ b/src/core/database/storage/WalletModelStorage.ts
@@ -13,16 +13,18 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-/**
- * A model that store some generic value based on the generation hash.
- */
-export type NetworkBasedModel<E> = Record<string, NetworkBasedEntryModel<E>>
 
-export class NetworkBasedEntryModel<E> {
+import {VersionedObjectStorage} from '@/core/database/backends/VersionedObjectStorage'
+import {WalletModel} from '@/core/database/entities/WalletModel'
 
-  public readonly timestamp = Date.now()
+export class WalletModelStorage extends VersionedObjectStorage<Record<string, WalletModel>> {
 
-  constructor(public readonly generationHash: string, public readonly data: E) {
+  /**
+   * Singleton instance as we want to run the migration just once
+   */
+  public static INSTANCE = new WalletModelStorage()
 
+  private constructor() {
+    super('wallets')
   }
 }

--- a/src/services/AccountService.ts
+++ b/src/services/AccountService.ts
@@ -15,8 +15,8 @@
  */
 import {Convert, Password, SHA3Hasher} from 'symbol-sdk'
 // internal dependencies
-import {SimpleObjectStorage} from '@/core/database/backends/SimpleObjectStorage'
 import {AccountModel} from '@/core/database/entities/AccountModel'
+import {AccountModelStorage} from '@/core/database/storage/AccountModelStorage'
 
 
 /**
@@ -28,8 +28,7 @@ export class AccountService {
    * The storage to keep user configuration around mosaics.  For example, the balance hidden
    * feature.
    */
-  private readonly accountsStorage = new SimpleObjectStorage<Record<string, AccountModel>>(
-    'accounts')
+  private readonly accountsStorage = AccountModelStorage.INSTANCE
 
 
   public getAccounts(): AccountModel[] {

--- a/src/services/MosaicService.ts
+++ b/src/services/MosaicService.ts
@@ -16,19 +16,20 @@
 // external dependencies
 import _ from 'lodash'
 import {AccountInfo, Address, MosaicId, MosaicInfo, MosaicNames, NamespaceId, RepositoryFactory, UInt64} from 'symbol-sdk'
-import {combineLatest, Observable, of, forkJoin} from 'rxjs'
+import {combineLatest, forkJoin, Observable, of} from 'rxjs'
 import {flatMap, map, tap, toArray} from 'rxjs/operators'
-
 // internal dependencies
 import {fromIterable} from 'rxjs/internal-compatibility'
 import {MosaicConfigurationModel} from '@/core/database/entities/MosaicConfigurationModel'
 import {MosaicModel} from '@/core/database/entities/MosaicModel'
 import {NetworkCurrencyModel} from '@/core/database/entities/NetworkCurrencyModel'
 import {ObservableHelpers} from '@/core/utils/ObservableHelpers'
-import {SimpleObjectStorage} from '@/core/database/backends/SimpleObjectStorage'
 import {TimeHelpers} from '@/core/utils/TimeHelpers'
 import {NetworkConfigurationModel} from '@/core/database/entities/NetworkConfigurationModel'
-import {NetworkBasedObjectStorage} from '@/core/database/backends/NetworkBasedObjectStorage'
+import {NetworkCurrenciesModel} from '@/core/database/entities/NetworkCurrenciesModel'
+import {MosaicModelStorage} from '@/core/database/storage/MosaicModelStorage'
+import {NetworkCurrenciesModelStorage} from '@/core/database/storage/NetworkCurrenciesModelStorage'
+import {MosaicConfigurationModelStorage} from '@/core/database/storage/MosaicConfigurationModelStorage'
 
 // custom types
 export type ExpirationStatus = 'unlimited' | 'expired' | string | number
@@ -43,10 +44,6 @@ export interface AttachedMosaic {
   amount: number
 }
 
-interface NetworkCurrenciesModel {
-  networkCurrency: NetworkCurrencyModel
-  harvestCurrency: NetworkCurrencyModel
-}
 
 interface MosaicBalance {
   mosaicId: MosaicId
@@ -66,19 +63,18 @@ export class MosaicService {
   /**
    * Store that caches the mosaic information of the current accounts when returned from rest.
    */
-  private readonly mosaicDataStorage = new NetworkBasedObjectStorage<MosaicModel[]>('mosaicCache')
+  private readonly mosaicDataStorage = MosaicModelStorage.INSTANCE
 
   /**
    * The storage to keep user configuration around mosaics.  For example, the balance hidden
    * feature.
    */
-  private readonly mosaicConfigurationsStorage = new SimpleObjectStorage<Record<string, MosaicConfigurationModel>>(
-    'mosaicConfiguration')
+  private readonly mosaicConfigurationsStorage = MosaicConfigurationModelStorage.INSTANCE
 
   /**
    * Store that caches the information around the network currency.
    */
-  private readonly networkCurrencyStorage = new NetworkBasedObjectStorage<NetworkCurrenciesModel>('networkCurrencyCache')
+  private readonly networkCurrencyStorage = NetworkCurrenciesModelStorage.INSTANCE
 
   /**
    * This method loads and caches the mosaic information for the given accounts.
@@ -97,6 +93,9 @@ export class MosaicService {
     networkCurrency: NetworkCurrencyModel,
     accountsInfo: AccountInfo[],
   ): Observable<MosaicModel[]> {
+    if (!accountsInfo.length){
+      return of([])
+    }
     const mosaicDataList = this.loadMosaicData(generationHash) || []
     const resolvedBalancesObservable = this.resolveBalances(repositoryFactory, accountsInfo)
     const accountAddresses = accountsInfo.map(a => a.address)
@@ -105,14 +104,26 @@ export class MosaicService {
 
     return combineLatest([ resolvedBalancesObservable, mosaicsFromAccountsObservable ])
       .pipe(flatMap(([ balances, owedMosaics ]) => {
-        const mosaicIds = _.uniqBy([ ...balances.map(m => m.mosaicId), ...owedMosaics.map(o => o.id) ], m => m.toHex())
+        const mosaicIds: MosaicId[] = _.uniqBy([ ...balances.map(m => m.mosaicId), ...owedMosaics.map(o => o.id) ],
+          m => m.toHex())
         const nameObservables = repositoryFactory.createNamespaceRepository().getMosaicsNames(mosaicIds)
-        const mosaicInfoObservable = repositoryFactory.createMosaicRepository().getMosaics(mosaicIds)
+        const mosaicInfoObservable = this.loadMosaic(repositoryFactory, mosaicIds, owedMosaics)
         return combineLatest([ nameObservables, mosaicInfoObservable ]).pipe(map(([ names, mosaicInfos ]) => {
           return this.toMosaicDtos(balances, mosaicInfos, names, networkCurrency, accountAddresses)
         }))
       })).pipe(tap((d) => this.saveMosaicData(generationHash, d)),
         ObservableHelpers.defaultFirst(mosaicDataList))
+  }
+
+  private loadMosaic(repositoryFactory: RepositoryFactory, mosaicIds: MosaicId[],
+    alreadyLoadedMosaics: MosaicInfo[]): Observable<MosaicInfo[]> {
+    const toLoadMosaicIds = mosaicIds.filter(mosaicId => !alreadyLoadedMosaics.some(info => info.id.equals(mosaicId)))
+    if (toLoadMosaicIds.length) {
+      return repositoryFactory.createMosaicRepository().getMosaics(toLoadMosaicIds)
+        .pipe(map(newMosaics => newMosaics.concat(alreadyLoadedMosaics)))
+    } else {
+      return of(alreadyLoadedMosaics)
+    }
   }
 
   private getName(mosaicNames: MosaicNames[], accountMosaicDto: MosaicId): string {
@@ -217,10 +228,8 @@ export class MosaicService {
         if (!thisMosaicNames) {throw new Error('thisMosaicNames not found at getNetworkCurrencies')}
         return this.getNetworkCurrency(mosaicInfo, thisMosaicNames)
       })),
-      map(networkMosaics => ({
-        networkCurrency: networkMosaics[0],
-        harvestCurrency: networkMosaics[1] || networkMosaics[0],
-      })),
+      map(networkMosaics => new NetworkCurrenciesModel(networkMosaics[0],
+        networkMosaics[1] || networkMosaics[0])),
       tap(d => this.networkCurrencyStorage.set(generationHash, d)),
       ObservableHelpers.defaultFirst(storedNetworkCurrencies),
     )

--- a/src/services/NamespaceService.ts
+++ b/src/services/NamespaceService.ts
@@ -16,13 +16,13 @@
 
 import {NamespaceModel} from '@/core/database/entities/NamespaceModel'
 import {Address, NamespaceName, RepositoryFactory} from 'symbol-sdk'
-import {Observable} from 'rxjs'
+import {Observable, of} from 'rxjs'
 import {flatMap, map, tap} from 'rxjs/operators'
 import {ObservableHelpers} from '@/core/utils/ObservableHelpers'
 import * as _ from 'lodash'
 import {TimeHelpers} from '@/core/utils/TimeHelpers'
 import {NetworkConfigurationModel} from '@/core/database/entities/NetworkConfigurationModel'
-import {NetworkBasedObjectStorage} from '@/core/database/backends/NetworkBasedObjectStorage'
+import {NamespaceModelStorage} from '@/core/database/storage/NamespaceModelStorage'
 
 /**
  * The service in charge of loading and caching anything related to Namepsaces from Rest.
@@ -33,8 +33,7 @@ export class NamespaceService {
   /**
    * The namespace information local cache.
    */
-  private readonly namespaceModelStorage = new NetworkBasedObjectStorage<NamespaceModel[]>(
-    'namespaceCache')
+  private readonly namespaceModelStorage = NamespaceModelStorage.INSTANCE
 
   /**
    * This method loads and caches the namespace information for the given accounts.
@@ -47,6 +46,9 @@ export class NamespaceService {
    */
   public getNamespaces(repositoryFactory: RepositoryFactory, generationHash: string,
     addresses: Address[]): Observable<NamespaceModel[]> {
+    if (!addresses.length){
+      return of([])
+    }
     const namespaceModelList = this.namespaceModelStorage.get(generationHash) || []
     const namespaceRepository = repositoryFactory.createNamespaceRepository()
     return namespaceRepository.getNamespacesFromAccounts(addresses)

--- a/src/services/NetworkService.ts
+++ b/src/services/NetworkService.ts
@@ -27,7 +27,7 @@ import networkConfig from '../../config/network.conf.json'
 import {fromIterable} from 'rxjs/internal-compatibility'
 import {NetworkConfigurationModel} from '@/core/database/entities/NetworkConfigurationModel'
 import {NetworkConfigurationHelpers} from '@/core/utils/NetworkConfigurationHelpers'
-import {NetworkBasedObjectStorage} from '@/core/database/backends/NetworkBasedObjectStorage'
+import {NetworkModelStorage} from '@/core/database/storage/NetworkModelStorage'
 
 /**
  * The service in charge of loading and caching anything related to Network from Rest.
@@ -37,7 +37,7 @@ export class NetworkService {
   /**
    * The network information local cache.
    */
-  private readonly storage = new NetworkBasedObjectStorage<NetworkModel>('networkCache')
+  private readonly storage = NetworkModelStorage.INSTANCE
 
   /**
    * The best default Url. It uses the stored condiguration if possible.

--- a/src/services/NodeService.ts
+++ b/src/services/NodeService.ts
@@ -20,10 +20,10 @@ import {ObservableHelpers} from '@/core/utils/ObservableHelpers'
 import {map, tap} from 'rxjs/operators'
 import {NodeModel} from '@/core/database/entities/NodeModel'
 import * as _ from 'lodash'
-import {SimpleObjectStorage} from '@/core/database/backends/SimpleObjectStorage'
 
 
 import networkConfig from '@/../config/network.conf.json'
+import {NodeModelStorage} from '@/core/database/storage/NodeModelStorage'
 
 /**
  * The service in charge of loading and caching anything related to Node and Peers from Rest.
@@ -34,7 +34,7 @@ export class NodeService {
   /**
    * The peer information local cache.
    */
-  private readonly storage = new SimpleObjectStorage<NodeModel[]>('node')
+  private readonly storage = NodeModelStorage.INSTANCE
 
   public getNodes(repositoryFactory: RepositoryFactory, repositoryFactoryUrl: string): Observable<NodeModel[]> {
     const storedNodes = this.loadNodes().concat(this.loadStaticNodes())

--- a/src/services/SettingService.ts
+++ b/src/services/SettingService.ts
@@ -14,13 +14,13 @@
  *
  */
 
-import {SimpleObjectStorage} from '@/core/database/backends/SimpleObjectStorage'
 import {SettingsModel} from '@/core/database/entities/SettingsModel'
 
 import feesConfig from '@/../config/fees.conf.json'
 import appConfig from '@/../config/app.conf.json'
 import networkConfig from '@/../config/network.conf.json'
 import i18n from '@/language'
+import {SettingsModelStorage} from '@/core/database/storage/SettingsModelStorage'
 
 
 /**
@@ -31,7 +31,7 @@ export class SettingService {
   /**
    * The the local storage that keeps the SettingsModel objects indexed by accountName.
    */
-  private readonly storage = new SimpleObjectStorage<Record<string, SettingsModel>>('settings')
+  private readonly storage = SettingsModelStorage.INSTANCE
 
   public getAccountSettings(accountName: string): SettingsModel {
     const storedData = this.storage.get() || {}

--- a/src/services/WalletService.ts
+++ b/src/services/WalletService.ts
@@ -21,10 +21,11 @@ import {DerivationPathValidator} from '@/core/validation/validators'
 import {WalletModel, WalletType} from '@/core/database/entities/WalletModel'
 import {AccountModel} from '@/core/database/entities/AccountModel'
 import {SimpleObjectStorage} from '@/core/database/backends/SimpleObjectStorage'
+import {WalletModelStorage} from '@/core/database/storage/WalletModelStorage'
 
 export class WalletService {
 
-  private readonly storage = new SimpleObjectStorage<Record<string, WalletModel>>('wallets')
+  private readonly storage = WalletModelStorage.INSTANCE
 
   /**
    * Default wallet derivation path

--- a/src/store/Transaction.ts
+++ b/src/store/Transaction.ts
@@ -265,7 +265,7 @@ export default {
         transactions.filter(t => t.transactionInfo.hash !== transactionHash))
     },
 
-    ON_NEW_TRANSACTION({dispatch}, transaction: Transaction): void {
+    async ON_NEW_TRANSACTION({dispatch}, transaction: Transaction) {
       if (!transaction) return
 
       // extract transaction types from the transaction
@@ -282,16 +282,9 @@ export default {
       ].some(a => transactionTypes.some(b => b === a))) {
         dispatch('namespace/LOAD_NAMESPACES', {}, {root: true})
       }
-      if ([
-        TransactionType.MOSAIC_DEFINITION,
-        TransactionType.MOSAIC_SUPPLY_CHANGE,
-      ].some(a => transactionTypes.some(b => b === a))) {
-        dispatch('mosaic/LOAD_MOSAICS', {}, {root: true})
-      }
-
-      if (transactionTypes.includes(TransactionType.MULTISIG_ACCOUNT_MODIFICATION)) {
-        dispatch('wallet/LOAD_ACCOUNT_INFO', {}, {root: true})
-      }
+      // Reloading Balances
+      await dispatch('wallet/LOAD_ACCOUNT_INFO', {}, {root: true})
+      dispatch('mosaic/LOAD_MOSAICS', {}, {root: true})
 
     },
     /// end-region scoped actions


### PR DESCRIPTION
Hi guys, I've implemented versioning.

The idea is that each table at top level has a version. A version per table, not per row like it used to be. Like this:

![image](https://user-images.githubusercontent.com/5390558/80556104-e18f5700-89a8-11ea-8351-59ba2f723027.png)

A table/storage may need more migrations that other tables. The migrations are handle per table/storage.

Then when the Storage object is created, the migration functions can be applied (if the stored version is old). Migration function is a function from A to A'. We are going to maintain a list of Migration functions when required. (Note that A can be a single value, a list, a complex object, etc)

Storage clients (like services) don't know about versioning, they just load/save/delete the model objects (not the top-level wrapper). 

Note that per model storage/table are singleton, they are created once just to run the migration once (if needed) per execution

Implements https://github.com/nemfoundation/symbol-desktop-wallet/issues/305

