### PR TITLE
Fixed aggregate and hash lock used max fee.

### DIFF
--- a/src/components/TransactionDetailsHeader/TransactionDetailsHeaderTs.ts
+++ b/src/components/TransactionDetailsHeader/TransactionDetailsHeaderTs.ts
@@ -76,7 +76,20 @@ export class TransactionDetailsHeaderTs extends Vue {
    */
   public getFeeAmount(): number {
     if (!this.view) return 0
-    return this.view.values.get('effectiveFee') || this.view.values.get('maxFee') || 0
+    const effectiveFee = this.view.values.get('effectiveFee')
+    if (effectiveFee !== undefined)
+    {return effectiveFee}
+    const maxFee = this.view.values.get('maxFee')
+    if (maxFee !== undefined)
+    {return maxFee}
+    return 0
+  }
+
+  public getFeeKey(): string {
+    if (this.view && this.view.values.get('effectiveFee') != undefined){
+      return 'paid_fee'
+    }
+    return 'max_fee'
   }
 
   /**
@@ -96,7 +109,7 @@ export class TransactionDetailsHeaderTs extends Vue {
         value: this.view.info ? this.view.info.hash : '-',
       },
       {
-        key: `${this.view.info ? 'paid_fee' : 'max_fee'}`,
+        key: this.getFeeKey(),
         value: {
           id: this.networkMosaic,
           mosaicHex: this.networkMosaicTicker,

--- a/src/components/TransactionList/TransactionRow/TransactionRowTs.ts
+++ b/src/components/TransactionList/TransactionRow/TransactionRowTs.ts
@@ -137,7 +137,14 @@ export class TransactionRowTs extends Vue {
     }
     // https://github.com/nemfoundation/nem2-desktop-account/issues/879
     // We may want to show N/A instead of the paid fee
-    return this.view.values.get('effectiveFee') || this.view.values.get('maxFee') || 0
+    if (!this.view) return 0
+    const effectiveFee = this.view.values.get('effectiveFee')
+    if (effectiveFee !== undefined)
+    {return effectiveFee}
+    const maxFee = this.view.values.get('maxFee')
+    if (maxFee !== undefined)
+    {return maxFee}
+    return 0
   }
 
   /**

--- a/src/store/Account.ts
+++ b/src/store/Account.ts
@@ -207,7 +207,7 @@ export default {
      *    skipTransactions: boolean,
      * }
      */
-    async initialize({commit, dispatch, getters}, {address}) {
+    async initialize({commit, getters}, {address}) {
       const callback = async () => {
         if (!address || !address.length) return
         commit('setInitialized', true)


### PR DESCRIPTION
Hotfix for https://github.com/nemfoundation/symbol-desktop-wallet/issues/196

The selected fee in the transaction form will be used for Hash and Aggregate (it was using the default setttings fee that could be too small / not enough)

Ideally, we should provide a dynamic "Recommended" fee selection calculated from the peer multiplier, transaction size and required cosignature (aggregate ones). This would be another PR/issue

- Fixed max fee and paid fee display for aggregate