### PR TITLE
fuzzy transfer form reset, fixes #328

### DIFF
--- a/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
+++ b/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
@@ -425,7 +425,6 @@ export class FormTransferTransactionTs extends FormTransactionBase {
    * Is necessary to make the mosaic inputs reactive
    */
   @Watch('selectedSigner')
-  @Watch('balanceMosaics')
   onSelectedSignerChange() {
     if (this.isMultisigMode) this.resetForm()
   }


### PR DESCRIPTION
This does the trick, there should be no need to reset the form on balances change since the mosaicInputManager should be reactive to new mosaics

So now it is reset one time (against 3), and the way to make it cleaner would be to have a loading state when changing signer/account,  that would put the transfer form in a loading state. 

IMO it is acceptable like that already