### PR TITLE
Handle console error "navigation duplicated"

### DIFF
--- a/src/router/AppRouter.ts
+++ b/src/router/AppRouter.ts
@@ -14,7 +14,7 @@
  *
  */
 // external dependencies
-import Router from 'vue-router'
+import Router, { RawLocation } from 'vue-router'
 // internal dependencies
 import { routes } from '@/router/routes'
 import { AppRoute } from './AppRoute'
@@ -36,6 +36,12 @@ export class AppRouter extends Router {
   constructor(options) {
     super(options)
     this.routes = options.routes
+    const originalPush = this.push
+    this.push = (location: RawLocation) => {
+      return originalPush.call(this, location).catch(() => {
+        /* eslint */
+      })
+    }
     this.beforeEach((to, from, next) => {
       const service = new ProfileService()
       const hasAccounts = service.getProfiles().length > 0


### PR DESCRIPTION
fixed #252
The root cause of this problem is the repeated triggering of asynchronous methods with routes.
Vue router did not deal with this problem well. Vue router chose to throw this error. For us, we have to deal with this mistake.