### PR TITLE
Upgrade settings to 951 testnet (fixes #401)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 .git
 .idea
 .vscode
+.run
 *.iml
 *.js.map
 /www

--- a/src/core/database/storage/SettingsModelStorage.ts
+++ b/src/core/database/storage/SettingsModelStorage.ts
@@ -24,6 +24,11 @@ export class SettingsModelStorage extends VersionedObjectStorage<Record<string, 
   public static INSTANCE = new SettingsModelStorage()
 
   private constructor() {
-    super('settings')
+    super('settings', [
+      {
+        description: 'Update settings to 0.9.5.1 network',
+        migrate: () => undefined,
+      },
+    ])
   }
 }


### PR DESCRIPTION
Add migration for `settings` to migrate older versions that could contain an invalid explorer url.