### PR TITLE
Auto disappear error message on FormProfileUnlock

### DIFF
--- a/src/views/forms/FormProfileUnlock/FormProfileUnlock.vue
+++ b/src/views/forms/FormProfileUnlock/FormProfileUnlock.vue
@@ -7,7 +7,6 @@
           <div class="row-75-25 inputs-container">
             <ValidationProvider
               v-slot="{ errors }"
-              mode="lazy"
               vid="password"
               :name="$t('password')"
               :rules="validationRules.profilePassword"


### PR DESCRIPTION
  *change validateProvider mode "lazy" to "default"(default value is "Aggressive") (fixed #411)